### PR TITLE
added custom css options to swap widget

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -3,9 +3,46 @@ import { IconAfter, IconBefore, Root } from './styles';
 import { ButtonProps } from './types';
 
 const Button: React.FC<ButtonProps> = (props) => {
-  const { iconBefore, children, iconAfter, loading, loadingText, as, target, ...rest } = props;
+  const {
+    iconBefore,
+    children,
+    iconAfter,
+    loading,
+    loadingText,
+    as,
+    target,
+    variant,
+    isDisabled,
+    btnPrimaryBgColor,
+    btnPrimaryTextColor,
+    btnSecondaryBgColor,
+    btnSecondaryTextColor,
+    btnConfirmedBgColor,
+    btnConfirmedTextColor,
+    ...rest
+  } = props;
+
+  const getBgColor = () => {
+    if (
+      ((btnPrimaryBgColor && btnPrimaryTextColor) ||
+        (btnSecondaryBgColor && btnSecondaryTextColor) ||
+        (btnConfirmedBgColor && btnConfirmedTextColor)) &&
+      !isDisabled
+    )
+      switch (variant) {
+        case 'primary':
+          return { backgroundColor: btnPrimaryBgColor, color: btnPrimaryTextColor };
+        case 'secondary':
+          return { backgroundColor: btnSecondaryBgColor, color: btnSecondaryTextColor };
+        case 'confirm':
+          return { backgroundColor: btnConfirmedBgColor, color: btnConfirmedTextColor };
+        default:
+          return {};
+      }
+  };
+
   return (
-    <Root {...rest} as={as} target={target}>
+    <Root {...rest} isDisabled={isDisabled} variant={variant} as={as} target={target} style={getBgColor()}>
       {loading ? (
         loadingText || 'Loading...'
       ) : (

--- a/src/components/Button/types.tsx
+++ b/src/components/Button/types.tsx
@@ -35,4 +35,13 @@ export type ButtonProps = {
   backgroundColor?: string;
   color?: string;
   borderColor?: string;
+  /** custom colors **/
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  btnSecondaryBgColor?: string;
+  btnSecondaryTextColor?: string;
+  btnConfirmedBgColor?: string;
+  btnConfirmedTextColor?: string;
+  btnDisabledBgColor?: string;
+  btnDisabledTextColor?: string;
 };

--- a/src/components/CurrencyInput/CurrencyInput.tsx
+++ b/src/components/CurrencyInput/CurrencyInput.tsx
@@ -8,7 +8,17 @@ import { Aligner, CurrencySelect, StyledTokenName } from './styles';
 import { CurrencyInputProps } from './types';
 
 const CurrencyInput: React.FC<CurrencyInputProps> = (props) => {
-  const { pair, currency, onTokenClick, ...rest } = props;
+  const {
+    pair,
+    currency,
+    onTokenClick,
+    textPrimaryColor,
+    textSecondaryColor,
+    selectPrimaryBgColor,
+    selectSecondaryBgColor,
+    inputFieldBgColor,
+    ...rest
+  } = props;
 
   const renderCurrency = () => {
     if (pair) {
@@ -23,13 +33,17 @@ const CurrencyInput: React.FC<CurrencyInputProps> = (props) => {
   const renderStyletoken = () => {
     if (pair) {
       return (
-        <StyledTokenName className="pair-name-container">
+        <StyledTokenName className="pair-name-container" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
           {pair?.token0.symbol}:{pair?.token1.symbol}
         </StyledTokenName>
       );
     } else
       return (
-        <StyledTokenName className="token-symbol-container" active={Boolean(currency && currency.symbol)}>
+        <StyledTokenName
+          className="token-symbol-container"
+          active={Boolean(currency && currency.symbol)}
+          style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+        >
           {(currency && currency.symbol && currency.symbol.length > 20
             ? currency.symbol.slice(0, 4) +
               '...' +
@@ -46,18 +60,33 @@ const CurrencyInput: React.FC<CurrencyInputProps> = (props) => {
         onClick={() => {
           onTokenClick && onTokenClick();
         }}
+        style={
+          selectSecondaryBgColor && selectPrimaryBgColor
+            ? Boolean(currency && currency.symbol)
+              ? { backgroundColor: selectSecondaryBgColor }
+              : { backgroundColor: selectPrimaryBgColor }
+            : {}
+        }
       >
         <Aligner>
           {renderCurrency()}
           {renderStyletoken()}
-          <ChevronDown color={!Boolean(currency && currency.symbol) ? 'black' : undefined} />
+          <ChevronDown
+            color={!Boolean(currency && currency.symbol) ? 'black' : undefined}
+            style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+          />
         </Aligner>
       </CurrencySelect>
     );
   };
   return (
     <Box>
-      <TextInput {...(rest as any)} addonAfter={addonAfter()} />
+      <TextInput
+        {...(rest as any)}
+        addonAfter={addonAfter()}
+        textSecondaryColor={textSecondaryColor}
+        inputFieldBgColor={inputFieldBgColor}
+      />
     </Box>
   );
 };

--- a/src/components/CurrencyInput/types.tsx
+++ b/src/components/CurrencyInput/types.tsx
@@ -5,4 +5,9 @@ export type CurrencyInputProps = TextInputProps & {
   currency?: Currency | null;
   pair?: Pair | null;
   onTokenClick?: () => void;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  selectPrimaryBgColor?: string;
+  selectSecondaryBgColor?: string;
+  inputFieldBgColor?: string;
 };

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -8,23 +8,43 @@ interface DrawerProps {
   onClose: () => void;
   children?: React.ReactNode;
   title?: string;
+  widgetBackground?: string;
   backgroundColor?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
 }
 
-export default function Drawer({ isOpen, onClose, children, title, backgroundColor }: DrawerProps) {
+export default function Drawer({
+  isOpen,
+  onClose,
+  children,
+  title,
+  backgroundColor,
+  widgetBackground,
+  textPrimaryColor,
+  textSecondaryColor,
+}: DrawerProps) {
   const theme = useContext(ThemeContext);
   return (
-    <DrawerRoot isOpen={isOpen} backgroundColor={backgroundColor}>
+    <DrawerRoot
+      isOpen={isOpen}
+      backgroundColor={backgroundColor}
+      style={widgetBackground ? { backgroundColor: widgetBackground } : {}}
+    >
       {title && (
         <Box display="flex" justifyContent="space-between" alignItems="center" padding="10px">
-          <Text color="text1" fontSize={24}>
+          <Text color="text1" fontSize={24} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
             {title}
           </Text>
         </Box>
       )}
 
       <Box position="absolute" right={10} top={10}>
-        <CloseIcon onClick={onClose} color={theme.text4} />
+        <CloseIcon
+          onClick={onClose}
+          color={theme.text4}
+          style={textSecondaryColor ? { stroke: textSecondaryColor } : {}}
+        />
       </Box>
 
       <DrawerContent>{children}</DrawerContent>

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -14,9 +14,10 @@ const PendingWrapper = styled(Box)`
 export interface Props {
   size: number;
   label?: string;
+  textPrimaryColor?: string;
 }
 const Loader: React.FC<Props> = (props) => {
-  const { size, label } = props;
+  const { size, label, textPrimaryColor } = props;
   return (
     <PendingWrapper>
       <Box mb={'15px'} display="flex" alignItems="center" flexDirection="column">
@@ -28,7 +29,14 @@ const Loader: React.FC<Props> = (props) => {
           </Box>
         </Box>
         {label && (
-          <Text fontWeight={500} fontSize={20} color="text1" textAlign="center" mt={10}>
+          <Text
+            fontWeight={500}
+            fontSize={20}
+            color="text1"
+            textAlign="center"
+            mt={10}
+            style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+          >
             {label}
           </Text>
         )}

--- a/src/components/NumberOptions/NumberOptions.tsx
+++ b/src/components/NumberOptions/NumberOptions.tsx
@@ -6,7 +6,16 @@ import { PValue } from './styled';
 import { NumberOptionsProps } from './types';
 
 const NumberOptions: React.FC<NumberOptionsProps> = (props) => {
-  const { options = [25, 50, 75, 100], isPercentage = false, onChange, currentValue, isDisabled, variant } = props;
+  const {
+    options = [25, 50, 75, 100],
+    isPercentage = false,
+    onChange,
+    currentValue,
+    isDisabled,
+    variant,
+    btnPrimaryBgColor,
+    btnPrimaryTextColor,
+  } = props;
   return (
     <Box>
       {variant === 'step' && (
@@ -34,6 +43,11 @@ const NumberOptions: React.FC<NumberOptionsProps> = (props) => {
               onClick={() => {
                 onChange && onChange(value);
               }}
+              style={
+                currentValue === value && btnPrimaryBgColor && btnPrimaryTextColor
+                  ? { backgroundColor: btnPrimaryBgColor, color: btnPrimaryTextColor }
+                  : {}
+              }
             >
               {isPercentage ? `${value}%` : value}
             </PValue>

--- a/src/components/NumberOptions/types.tsx
+++ b/src/components/NumberOptions/types.tsx
@@ -5,4 +5,6 @@ export interface NumberOptionsProps {
   currentValue: number;
   isDisabled?: boolean;
   variant: 'step' | 'box';
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
 }

--- a/src/components/SwapWidget/ConfirmLimitOrderDrawer/FiateValue/index.tsx
+++ b/src/components/SwapWidget/ConfirmLimitOrderDrawer/FiateValue/index.tsx
@@ -7,9 +7,11 @@ import { Text } from '../../../Text';
 export function FiatValue({
   fiatValue,
   priceImpact,
+  textPrimaryColor,
 }: {
   fiatValue: CurrencyAmount | null | undefined;
   priceImpact?: Percent;
+  textPrimaryColor?: string;
 }) {
   const theme = useContext(ThemeContext);
   const priceImpactColor = useMemo(() => {
@@ -22,7 +24,12 @@ export function FiatValue({
   }, [priceImpact, theme.green1, theme.red1, theme.text4, theme.yellow1]);
 
   return (
-    <Text fontSize={14} color={fiatValue ? 'text2' : 'text4'} ml={10}>
+    <Text
+      fontSize={14}
+      color={fiatValue ? 'text2' : 'text4'}
+      ml={10}
+      style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+    >
       {fiatValue ? '~' : ''}${fiatValue ? fiatValue?.toSignificant(6, { groupSeparator: ',' }) : '-'}
       {priceImpact ? (
         <span style={{ color: priceImpactColor }}> ({priceImpact.multiply('-1').toSignificant(3)}%)</span>

--- a/src/components/SwapWidget/ConfirmLimitOrderDrawer/index.tsx
+++ b/src/components/SwapWidget/ConfirmLimitOrderDrawer/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { useGelatoLimitOrders } from '@gelatonetwork/limit-orders-react';
 import { CAVAX, Token, Trade, TradeType } from '@pangolindex/sdk';
 import React, { useCallback, useContext, useState } from 'react';
@@ -35,11 +36,32 @@ interface Props {
   onConfirm: () => void;
   swapErrorMessage: string | undefined;
   onClose: () => void;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  inputFieldBgColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
 }
 
 const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
-  const { isOpen, onClose, trade, onAcceptChanges, recipient, onConfirm, attemptingTxn, swapErrorMessage, txHash } =
-    props;
+  const {
+    isOpen,
+    onClose,
+    trade,
+    onAcceptChanges,
+    recipient,
+    onConfirm,
+    attemptingTxn,
+    swapErrorMessage,
+    txHash,
+    widgetBackground,
+    textPrimaryColor,
+    textSecondaryColor,
+    inputFieldBgColor,
+    btnPrimaryBgColor,
+    btnPrimaryTextColor,
+  } = props;
   const [showInverted, setShowInverted] = useState<boolean>(false);
   const chainId = useChainId();
   const theme = useContext(ThemeContext);
@@ -146,15 +168,28 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
             fontSize={24}
             fontWeight={500}
             color={showAcceptChanges && trade.tradeType === TradeType.EXACT_OUTPUT ? 'primary' : 'text1'}
-            style={{ marginLeft: '12px' }}
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '12px' } : { marginLeft: '12px' }}
           >
             {inputAmount.toSignificant(6)}
           </Text>
-          <Text fontSize={24} fontWeight={500} color="text1" style={{ marginLeft: '10px' }}>
+          <Text
+            fontSize={24}
+            fontWeight={500}
+            color="text1"
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '10px' } : { marginLeft: '10px' }}
+          >
             {inputCurrency?.symbol}
           </Text>
         </TokenRow>
-        <ArrowDown size="16" color={theme.text2} style={{ marginLeft: '4px', minWidth: '16px' }} />
+        <ArrowDown
+          size="16"
+          color={theme.text2}
+          style={
+            textPrimaryColor
+              ? { stroke: textPrimaryColor, marginLeft: '4px', minWidth: '16px' }
+              : { marginLeft: '4px', minWidth: '16px' }
+          }
+        />
         <TokenRow>
           <CurrencyLogo currency={outputCurrency} size={24} imageSize={48} />
 
@@ -162,7 +197,7 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
             <Text
               fontSize={24}
               fontWeight={500}
-              style={{ marginLeft: '12px' }}
+              style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '12px' } : { marginLeft: '12px' }}
               color={showAcceptChanges && trade.tradeType === TradeType.EXACT_INPUT ? 'primary' : 'text1'}
             >
               {outputAmount.toSignificant(6)}
@@ -171,18 +206,31 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
             <FiatValue
               fiatValue={fiatValueOutput as any}
               priceImpact={computeFiatValuePriceImpact(fiatValueInput as any, fiatValueOutput as any) as any}
+              textPrimaryColor={textPrimaryColor}
             />
           </Box>
-          <Text fontSize={24} fontWeight={500} color="text1" style={{ marginLeft: '10px' }}>
+          <Text
+            fontSize={24}
+            fontWeight={500}
+            color="text1"
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '10px' } : { marginLeft: '10px' }}
+          >
             {outputCurrency?.symbol}
           </Text>
         </TokenRow>
         {showAcceptChanges && (
           <PriceUpdateBlock>
-            <Text color={'text1'} fontSize={14}>
+            <Text color={'text1'} fontSize={14} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               Price Updated
             </Text>
-            <Button onClick={onAcceptChanges} variant="primary" width={150} padding="5px 10px">
+            <Button
+              onClick={onAcceptChanges}
+              variant="primary"
+              width={150}
+              padding="5px 10px"
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              btnPrimaryTextColor={btnPrimaryTextColor}
+            >
               Accept
             </Button>
           </PriceUpdateBlock>
@@ -196,15 +244,15 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
           onClick={flipPrice}
           style={{ cursor: 'pointer' }}
         >
-          <Text color={'text1'} fontSize={16}>
+          <Text color={'text1'} fontSize={16} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
             Limit Price
           </Text>
-          <Text color={'text1'} fontSize={16}>
+          <Text color={'text1'} fontSize={16} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
             {text}
           </Text>
         </Box>
         <Box mt={'15px'}>
-          <Text color={'text1'} fontSize={16}>
+          <Text color={'text1'} fontSize={16} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
             Output will be sent to{' '}
             <b title={recipient || ''}>
               {isAddress(recipient || '') ? shortenAddress(recipient || '', chainId) : recipient || ''}
@@ -213,7 +261,11 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
         </Box>
       </Header>
       <Footer>
-        <LimitOrderDetailInfo trade={trade} />
+        <LimitOrderDetailInfo
+          trade={trade}
+          textSecondaryColor={textSecondaryColor}
+          inputFieldBgColor={inputFieldBgColor}
+        />
         <Box my={'10px'}>
           <Button variant="primary" onClick={onConfirm} isDisabled={showAcceptChanges}>
             Confirm Order
@@ -223,7 +275,7 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
     </Root>
   );
 
-  const PendingContent = <Loader size={100} label={pendingText} />;
+  const PendingContent = <Loader size={100} label={pendingText} textPrimaryColor={textPrimaryColor} />;
 
   const ErroContent = (
     <ErrorWrapper>
@@ -233,7 +285,12 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
           {swapErrorMessage}
         </Text>
       </ErrorBox>
-      <Button variant="primary" onClick={onClose}>
+      <Button
+        variant="primary"
+        onClick={onClose}
+        btnPrimaryBgColor={btnPrimaryBgColor}
+        btnPrimaryTextColor={btnPrimaryTextColor}
+      >
         Dismiss
       </Button>
     </ErrorWrapper>
@@ -243,9 +300,14 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
     <SubmittedWrapper>
       <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center" paddingY={'20px'}>
         <Box flex="1" display="flex" alignItems="center">
-          <ArrowUpCircle strokeWidth={0.5} size={90} color={theme.primary} />
+          <ArrowUpCircle
+            strokeWidth={0.5}
+            size={90}
+            color={theme.primary}
+            style={textPrimaryColor ? { stroke: btnPrimaryBgColor } : {}}
+          />
         </Box>
-        <Text fontWeight={500} fontSize={20} color="text1">
+        <Text fontWeight={500} fontSize={20} color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
           Transaction Submitted
         </Text>
         {chainId && txHash && (
@@ -261,7 +323,12 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
           </Link>
         )}
       </Box>
-      <Button variant="primary" onClick={onClose}>
+      <Button
+        variant="primary"
+        onClick={onClose}
+        btnPrimaryBgColor={btnPrimaryBgColor}
+        btnPrimaryTextColor={btnPrimaryTextColor}
+      >
         Close
       </Button>
     </SubmittedWrapper>
@@ -284,6 +351,9 @@ const ConfirmLimitOrderDrawer: React.FC<Props> = (props) => {
       title={swapErrorMessage || txHash || attemptingTxn ? '' : 'Confirm Order'}
       isOpen={isOpen}
       onClose={onClose}
+      widgetBackground={widgetBackground}
+      textPrimaryColor={textPrimaryColor}
+      textSecondaryColor={textSecondaryColor}
     >
       {getSwapError()}
     </Drawer>

--- a/src/components/SwapWidget/ConfirmSwapDrawer/index.tsx
+++ b/src/components/SwapWidget/ConfirmSwapDrawer/index.tsx
@@ -34,6 +34,12 @@ interface Props {
   onConfirm: () => void;
   swapErrorMessage: string | undefined;
   onClose: () => void;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  inputFieldBgColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
 }
 
 const ConfirmSwapDrawer: React.FC<Props> = (props) => {
@@ -49,6 +55,12 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
     swapErrorMessage,
     txHash,
     recipient,
+    widgetBackground,
+    textPrimaryColor,
+    textSecondaryColor,
+    inputFieldBgColor,
+    btnPrimaryBgColor,
+    btnPrimaryTextColor,
   } = props;
 
   const { chainId } = usePangolinWeb3();
@@ -80,21 +92,34 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
             fontSize={24}
             fontWeight={500}
             color={showAcceptChanges && trade.tradeType === TradeType.EXACT_OUTPUT ? 'primary' : 'text1'}
-            style={{ marginLeft: '12px' }}
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '12px' } : { marginLeft: '12px' }}
           >
             {trade.inputAmount.toSignificant(6)}
           </Text>
-          <Text fontSize={24} fontWeight={500} color="text1" style={{ marginLeft: '10px' }}>
+          <Text
+            fontSize={24}
+            fontWeight={500}
+            color="text1"
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '10px' } : { marginLeft: '10px' }}
+          >
             {trade.inputAmount.currency.symbol}
           </Text>
         </TokenRow>
-        <ArrowDown size="16" color={theme.text2} style={{ marginLeft: '4px', minWidth: '16px' }} />
+        <ArrowDown
+          size="16"
+          color={theme.text2}
+          style={
+            textPrimaryColor
+              ? { stroke: textPrimaryColor, marginLeft: '4px', minWidth: '16px' }
+              : { marginLeft: '4px', minWidth: '16px' }
+          }
+        />
         <TokenRow>
           <CurrencyLogo currency={trade.outputAmount.currency} size={24} imageSize={48} />
           <Text
             fontSize={24}
             fontWeight={500}
-            style={{ marginLeft: '12px' }}
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '12px' } : { marginLeft: '12px' }}
             color={
               priceImpactSeverity > 2
                 ? 'red1'
@@ -105,23 +130,35 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
           >
             {trade.outputAmount.toSignificant(6)}
           </Text>
-          <Text fontSize={24} fontWeight={500} color="text1" style={{ marginLeft: '10px' }}>
+          <Text
+            fontSize={24}
+            fontWeight={500}
+            color="text1"
+            style={textPrimaryColor ? { color: textPrimaryColor, marginLeft: '10px' } : { marginLeft: '10px' }}
+          >
             {trade.outputAmount.currency.symbol}
           </Text>
         </TokenRow>
         {showAcceptChanges && (
           <PriceUpdateBlock>
-            <Text color={'text1'} fontSize={14}>
+            <Text color={'text1'} fontSize={14} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               Price Updated
             </Text>
-            <Button onClick={onAcceptChanges} variant="primary" width={150} padding="5px 10px">
+            <Button
+              onClick={onAcceptChanges}
+              variant="primary"
+              width={150}
+              padding="5px 10px"
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              btnPrimaryTextColor={btnPrimaryTextColor}
+            >
               Accept
             </Button>
           </PriceUpdateBlock>
         )}
         <Box mt={'15px'}>
           {trade.tradeType === TradeType.EXACT_INPUT ? (
-            <OutputText color="text2">
+            <OutputText color="text2" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               Output is estimated. You will receive at least
               <b>
                 {slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(6)} {trade.outputAmount.currency.symbol}
@@ -129,7 +166,7 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
               or the transaction will revert.
             </OutputText>
           ) : (
-            <OutputText color="text2">
+            <OutputText color="text2" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               Input is estimated. You will sell at most
               <b>
                 {slippageAdjustedAmounts[Field.INPUT]?.toSignificant(6)} {trade.inputAmount.currency.symbol}
@@ -138,12 +175,22 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
             </OutputText>
           )}
         </Box>
-        {recipient && <OutputText color="text1">Sending to: {recipient}</OutputText>}
+        {recipient && (
+          <OutputText color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
+            Sending to: {recipient}
+          </OutputText>
+        )}
       </Header>
       <Footer>
-        <SwapDetailInfo trade={trade} />
+        <SwapDetailInfo trade={trade} textSecondaryColor={textSecondaryColor} inputFieldBgColor={inputFieldBgColor} />
         <Box my={'10px'}>
-          <Button variant="primary" onClick={onConfirm} isDisabled={showAcceptChanges}>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            isDisabled={showAcceptChanges}
+            btnPrimaryBgColor={btnPrimaryBgColor}
+            btnPrimaryTextColor={btnPrimaryTextColor}
+          >
             {priceImpactSeverity > 2 ? 'Swap Anyway' : 'Confirm Swap'}
           </Button>
         </Box>
@@ -151,7 +198,7 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
     </Root>
   );
 
-  const PendingContent = <Loader size={100} label={pendingText} />;
+  const PendingContent = <Loader size={100} label={pendingText} textPrimaryColor={textPrimaryColor} />;
 
   const ErroContent = (
     <ErrorWrapper>
@@ -161,7 +208,12 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
           {swapErrorMessage}
         </Text>
       </ErrorBox>
-      <Button variant="primary" onClick={onClose}>
+      <Button
+        variant="primary"
+        onClick={onClose}
+        btnPrimaryBgColor={btnPrimaryBgColor}
+        btnPrimaryTextColor={btnPrimaryTextColor}
+      >
         Dismiss
       </Button>
     </ErrorWrapper>
@@ -171,9 +223,14 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
     <SubmittedWrapper>
       <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center" paddingY={'20px'}>
         <Box flex="1" display="flex" alignItems="center">
-          <ArrowUpCircle strokeWidth={0.5} size={90} color={theme.primary} />
+          <ArrowUpCircle
+            strokeWidth={0.5}
+            size={90}
+            color={theme.primary}
+            style={textPrimaryColor ? { stroke: btnPrimaryBgColor } : {}}
+          />
         </Box>
-        <Text fontWeight={500} fontSize={20} color="text1">
+        <Text fontWeight={500} fontSize={20} color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
           Transaction Submitted
         </Text>
         {chainId && txHash && (
@@ -188,14 +245,26 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
           </Link>
         )}
       </Box>
-      <Button variant="primary" onClick={onClose}>
+      <Button
+        variant="primary"
+        onClick={onClose}
+        btnPrimaryBgColor={btnPrimaryBgColor}
+        btnPrimaryTextColor={btnPrimaryTextColor}
+      >
         Close
       </Button>
     </SubmittedWrapper>
   );
 
   return (
-    <Drawer title={swapErrorMessage || txHash || attemptingTxn ? '' : 'Confirm Swap'} isOpen={isOpen} onClose={onClose}>
+    <Drawer
+      title={swapErrorMessage || txHash || attemptingTxn ? '' : 'Confirm Swap'}
+      isOpen={isOpen}
+      onClose={onClose}
+      widgetBackground={widgetBackground}
+      textPrimaryColor={textPrimaryColor}
+      textSecondaryColor={textSecondaryColor}
+    >
       {swapErrorMessage ? ErroContent : txHash ? SubmittedContent : attemptingTxn ? PendingContent : ConfirmContent}
     </Drawer>
   );

--- a/src/components/SwapWidget/LimitOrder/index.tsx
+++ b/src/components/SwapWidget/LimitOrder/index.tsx
@@ -32,9 +32,41 @@ interface Props {
   swapType: string;
   setSwapType: (value: string) => void;
   isLimitOrderVisible: boolean;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  btnConfirmedBgColor?: string;
+  btnConfirmedTextColor?: string;
+  settingsBtnBgColor?: string;
+  selectPrimaryBgColor?: string;
+  selectSecondaryBgColor?: string;
+  toggleBgColor?: string;
+  toggleSelectedColor?: string;
+  toggleTextColor?: string;
+  inputFieldBgColor?: string;
 }
 
-const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisible }) => {
+const LimitOrder: React.FC<Props> = ({
+  swapType,
+  setSwapType,
+  isLimitOrderVisible,
+  widgetBackground,
+  textPrimaryColor,
+  textSecondaryColor,
+  btnPrimaryBgColor,
+  btnPrimaryTextColor,
+  btnConfirmedBgColor,
+  btnConfirmedTextColor,
+  settingsBtnBgColor,
+  selectPrimaryBgColor,
+  selectSecondaryBgColor,
+  toggleBgColor,
+  toggleSelectedColor,
+  toggleTextColor,
+  inputFieldBgColor,
+}) => {
   const [isTokenDrawerOpen, setIsTokenDrawerOpen] = useState(false);
   const [selectedPercentage, setSelectedPercentage] = useState(0);
   const [tokenDrawerType, setTokenDrawerType] = useState(LimitNewField.INPUT);
@@ -351,7 +383,13 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
   const renderButton = () => {
     if (!account) {
       return (
-        <Button isDisabled={!account} variant="primary" onClick={toggleWalletModal}>
+        <Button
+          isDisabled={!account}
+          variant="primary"
+          onClick={toggleWalletModal}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+        >
           Connect Wallet
         </Button>
       );
@@ -367,6 +405,10 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
               isDisabled={approval !== ApprovalState.NOT_APPROVED || approvalSubmitted}
               loading={approval === ApprovalState.PENDING}
               loadingText="Approving"
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              btnPrimaryTextColor={btnPrimaryTextColor}
+              btnConfirmedBgColor={btnConfirmedBgColor}
+              btnConfirmedTextColor={btnConfirmedTextColor}
             >
               {approvalSubmitted && approval === ApprovalState.APPROVED
                 ? 'Approved'
@@ -419,6 +461,7 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
                 onUserInput(LimitNewField.INPUT as any, newFinalAmount.toExact());
               }
             }}
+            style={textSecondaryColor ? { color: textSecondaryColor } : {}}
           >
             {value}%
           </PValue>
@@ -438,9 +481,19 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
 
   return (
     <Root>
-      <TradeOption swapType={swapType} setSwapType={setSwapType} isLimitOrderVisible={isLimitOrderVisible} />
+      <TradeOption
+        swapType={swapType}
+        setSwapType={setSwapType}
+        isLimitOrderVisible={isLimitOrderVisible}
+        widgetBackground={widgetBackground}
+        textPrimaryColor={textPrimaryColor}
+        settingsBtnBgColor={settingsBtnBgColor}
+        toggleBgColor={toggleBgColor}
+        toggleSelectedColor={toggleSelectedColor}
+        toggleTextColor={toggleTextColor}
+      />
 
-      <SwapWrapper>
+      <SwapWrapper style={widgetBackground ? { backgroundColor: widgetBackground } : {}}>
         <Box width="100%" display="flex" justifyContent="center">
           <Box textAlign="center" width="120px">
             <ToggleButtons
@@ -449,6 +502,9 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
               onChange={(value) => {
                 handleActiveTab(value);
               }}
+              toggleBgColor={toggleBgColor}
+              toggleSelectedColor={toggleSelectedColor}
+              toggleTextColor={toggleTextColor}
             />
           </Box>
         </Box>
@@ -473,14 +529,24 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
             placeholder="0.00"
             id="swap-currency-input"
             addonLabel={renderPercentage()}
+            textPrimaryColor={textPrimaryColor}
+            textSecondaryColor={textSecondaryColor}
+            selectPrimaryBgColor={selectPrimaryBgColor}
+            selectSecondaryBgColor={selectSecondaryBgColor}
+            inputFieldBgColor={inputFieldBgColor}
+            style={
+              inputFieldBgColor && textSecondaryColor
+                ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                : {}
+            }
           />
 
           <Box width="100%" textAlign="center" alignItems="center" display="flex" justifyContent={'center'} mt={10}>
             <ArrowWrapper>
               {rateType === Rate.MUL ? (
-                <X size="16" color={determineColor()} />
+                <X size="16" color={textSecondaryColor ? textSecondaryColor : determineColor()} />
               ) : (
-                <Divide size="16" color={determineColor()} />
+                <Divide size="16" color={textSecondaryColor ? textSecondaryColor : determineColor()} />
               )}
             </ArrowWrapper>
           </Box>
@@ -493,6 +559,13 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
               isNumeric={true}
               placeholder="0.00"
               label="Price"
+              textSecondaryColor={textSecondaryColor}
+              inputFieldBgColor={inputFieldBgColor}
+              style={
+                inputFieldBgColor && textSecondaryColor
+                  ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                  : {}
+              }
             />
           </Box>
           <Box width="100%" textAlign="center" alignItems="center" display="flex" justifyContent={'center'} mt={10}>
@@ -502,7 +575,7 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
                 onSwitchTokens();
               }}
             >
-              <RefreshCcw size="16" color={theme.text4} />
+              <RefreshCcw size="16" color={textSecondaryColor ? textSecondaryColor : theme.text4} />
             </ArrowWrapper>
           </Box>
           <CurrencyInputTextBox
@@ -523,14 +596,30 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
             id="swap-currency-output"
             addonLabel={
               tradePrice && (
-                <Text color="text4" fontSize={16}>
+                <Text color="text4" fontSize={16} style={textSecondaryColor ? { color: textSecondaryColor } : {}}>
                   Price: {tradePrice?.toSignificant(6)} {tradePrice?.quoteCurrency?.symbol}
                 </Text>
               )
             }
+            textPrimaryColor={textPrimaryColor}
+            textSecondaryColor={textSecondaryColor}
+            selectPrimaryBgColor={selectPrimaryBgColor}
+            selectSecondaryBgColor={selectSecondaryBgColor}
+            inputFieldBgColor={inputFieldBgColor}
+            style={
+              inputFieldBgColor && textSecondaryColor
+                ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                : {}
+            }
           />
 
-          {trade && <LimitOrderDetailInfo trade={trade} />}
+          {trade && (
+            <LimitOrderDetailInfo
+              trade={trade}
+              textSecondaryColor={textSecondaryColor}
+              inputFieldBgColor={inputFieldBgColor}
+            />
+          )}
 
           <Box width="100%" mt={10}>
             {renderButton()}
@@ -545,6 +634,10 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
         onCurrencySelect={onCurrencySelect}
         selectedCurrency={tokenDrawerType === (LimitNewField.INPUT as any) ? inputCurrency : outputCurrency}
         otherSelectedCurrency={tokenDrawerType === (LimitNewField.INPUT as any) ? outputCurrency : inputCurrency}
+        widgetBackground={widgetBackground}
+        textPrimaryColor={textPrimaryColor}
+        textSecondaryColor={textSecondaryColor}
+        inputFieldBgColor={inputFieldBgColor}
       />
 
       {/* Confirm Swap Drawer */}
@@ -561,6 +654,12 @@ const LimitOrder: React.FC<Props> = ({ swapType, setSwapType, isLimitOrderVisibl
           onConfirm={handleSwap}
           swapErrorMessage={swapErrorMessage}
           onClose={handleConfirmDismiss}
+          widgetBackground={widgetBackground}
+          textPrimaryColor={textPrimaryColor}
+          textSecondaryColor={textSecondaryColor}
+          inputFieldBgColor={inputFieldBgColor}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
         />
       )}
     </Root>

--- a/src/components/SwapWidget/LimitOrderDetailInfo/index.tsx
+++ b/src/components/SwapWidget/LimitOrderDetailInfo/index.tsx
@@ -7,9 +7,9 @@ import { usePangolinWeb3 } from 'src/hooks';
 import { Text } from '../../Text';
 import { ContentBox, DataBox, ValueText } from './styled';
 
-type Props = { trade: any };
+type Props = { trade: any; textSecondaryColor?: string; inputFieldBgColor?: string };
 
-const LimitOrderDetailInfo: React.FC<Props> = ({ trade }) => {
+const LimitOrderDetailInfo: React.FC<Props> = ({ trade, textSecondaryColor, inputFieldBgColor }) => {
   const { chainId } = usePangolinWeb3();
 
   const {
@@ -58,17 +58,19 @@ const LimitOrderDetailInfo: React.FC<Props> = ({ trade }) => {
   const renderRow = (label: string, value: string) => {
     return (
       <DataBox key={label}>
-        <Text color="text4" fontSize={14}>
+        <Text color="text4" fontSize={14} style={textSecondaryColor ? { color: textSecondaryColor } : {}}>
           {label}
         </Text>
 
-        <ValueText fontSize={14}>{value}</ValueText>
+        <ValueText fontSize={14} style={textSecondaryColor ? { color: textSecondaryColor } : {}}>
+          {value}
+        </ValueText>
       </DataBox>
     );
   };
 
   return (
-    <ContentBox>
+    <ContentBox style={inputFieldBgColor ? { backgroundColor: inputFieldBgColor } : {}}>
       {renderRow('Gas Price', `${formattedGasPrice}`)}
       {renderRow('Real Execution Price', `${realExecutionPriceAsString ? `${priceText}` : '-'}`)}
       {renderRow('Gelato Fee', `${gelatoFeePercentage ? `${gelatoFeePercentage}` : '-'}%`)}

--- a/src/components/SwapWidget/MarketOrder/index.tsx
+++ b/src/components/SwapWidget/MarketOrder/index.tsx
@@ -46,6 +46,21 @@ interface Props {
   isLimitOrderVisible: boolean;
   showSettings: boolean;
   partnerDaaS?: string;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  btnConfirmedBgColor?: string;
+  btnConfirmedTextColor?: string;
+  settingsBtnBgColor?: string;
+  selectPrimaryBgColor?: string;
+  selectSecondaryBgColor?: string;
+  toggleBgColor?: string;
+  toggleSelectedColor?: string;
+  toggleTextColor?: string;
+  inputFieldBgColor?: string;
+  switchOnHandleColor?: string;
 }
 
 const MarketOrder: React.FC<Props> = ({
@@ -54,6 +69,21 @@ const MarketOrder: React.FC<Props> = ({
   isLimitOrderVisible,
   showSettings,
   partnerDaaS = ZERO_ADDRESS,
+  widgetBackground,
+  textPrimaryColor,
+  textSecondaryColor,
+  btnPrimaryBgColor,
+  btnPrimaryTextColor,
+  btnConfirmedBgColor,
+  btnConfirmedTextColor,
+  settingsBtnBgColor,
+  selectPrimaryBgColor,
+  selectSecondaryBgColor,
+  toggleBgColor,
+  toggleSelectedColor,
+  toggleTextColor,
+  inputFieldBgColor,
+  switchOnHandleColor,
 }) => {
   // const [isRetryDrawerOpen, setIsRetryDrawerOpen] = useState(false);
   const [isTokenDrawerOpen, setIsTokenDrawerOpen] = useState(false);
@@ -330,7 +360,19 @@ const MarketOrder: React.FC<Props> = ({
   if (openSettings && showSettings) {
     return (
       <Box minHeight={450}>
-        <SwapSettingsDrawer isOpen={openSettings} close={closeSwapSettings} />
+        <SwapSettingsDrawer
+          isOpen={openSettings}
+          close={closeSwapSettings}
+          widgetBackground={widgetBackground}
+          textPrimaryColor={textPrimaryColor}
+          textSecondaryColor={textSecondaryColor}
+          inputFieldBgColor={inputFieldBgColor}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+          toggleBgColor={toggleBgColor}
+          toggleSelectedColor={toggleSelectedColor}
+          toggleTextColor={toggleTextColor}
+        />
       </Box>
     );
   }
@@ -338,28 +380,50 @@ const MarketOrder: React.FC<Props> = ({
   const renderButton = () => {
     if (!account) {
       return (
-        <Button isDisabled={!account} variant="primary" onClick={toggleWalletModal}>
+        <Button
+          isDisabled={!account}
+          variant="primary"
+          onClick={toggleWalletModal}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+        >
           Connect Wallet
         </Button>
       );
     }
     if (showWrap) {
       return (
-        <Button variant="primary" isDisabled={Boolean(wrapInputError)} onClick={onWrap}>
+        <Button
+          variant="primary"
+          isDisabled={Boolean(wrapInputError)}
+          onClick={onWrap}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+        >
           {wrapInputError ?? (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'unwrap' : null)}
         </Button>
       );
     }
     if (isLoadingSwap && !swapInputError) {
       return (
-        <Button variant="primary" isDisabled>
+        <Button
+          variant="primary"
+          isDisabled
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+        >
           Loading
         </Button>
       );
     }
     if (noRoute && userHasSpecifiedInputOutput) {
       return (
-        <Button variant="primary" isDisabled>
+        <Button
+          variant="primary"
+          isDisabled
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+        >
           Insufficient liquidity for this trade.
         </Button>
       );
@@ -375,6 +439,10 @@ const MarketOrder: React.FC<Props> = ({
               isDisabled={approval !== ApprovalState.NOT_APPROVED || approvalSubmitted}
               loading={approval === ApprovalState.PENDING}
               loadingText="Approving"
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              btnPrimaryTextColor={btnPrimaryTextColor}
+              btnConfirmedBgColor={btnConfirmedBgColor}
+              btnConfirmedTextColor={btnConfirmedTextColor}
             >
               {approvalSubmitted && approval === ApprovalState.APPROVED
                 ? 'Approved'
@@ -396,6 +464,8 @@ const MarketOrder: React.FC<Props> = ({
             id="swap-button"
             isDisabled={!isValid || approval !== ApprovalState.APPROVED || (priceImpactSeverity > 3 && !isExpertMode)}
             // error={isValid && priceImpactSeverity > 2}
+            btnPrimaryBgColor={btnPrimaryBgColor}
+            btnPrimaryTextColor={btnPrimaryTextColor}
           >
             {priceImpactSeverity > 3 && !isExpertMode
               ? 'Price Impact High'
@@ -421,6 +491,8 @@ const MarketOrder: React.FC<Props> = ({
         isDisabled={!isValid || (priceImpactSeverity > 3 && !isExpertMode) || !!swapCallbackError || !!swapInputError}
         backgroundColor={isValid && priceImpactSeverity > 2 ? 'primary' : undefined}
         color={isValid && priceImpactSeverity <= 2 ? 'black' : undefined}
+        btnPrimaryBgColor={btnPrimaryBgColor}
+        btnPrimaryTextColor={btnPrimaryTextColor}
       >
         {swapInputError
           ? swapInputError
@@ -450,6 +522,7 @@ const MarketOrder: React.FC<Props> = ({
                 onUserInput(Field.INPUT, newFinalAmount.toExact());
               }
             }}
+            style={textSecondaryColor ? { color: textSecondaryColor } : {}}
           >
             {value}%
           </PValue>
@@ -466,6 +539,12 @@ const MarketOrder: React.FC<Props> = ({
         isLimitOrderVisible={isLimitOrderVisible}
         showSettings={showSettings}
         openSwapSettings={openSwapSettings}
+        widgetBackground={widgetBackground}
+        textPrimaryColor={textPrimaryColor}
+        settingsBtnBgColor={settingsBtnBgColor}
+        toggleBgColor={toggleBgColor}
+        toggleSelectedColor={toggleSelectedColor}
+        toggleTextColor={toggleTextColor}
       />
 
       <TokenWarningModal
@@ -474,10 +553,9 @@ const MarketOrder: React.FC<Props> = ({
         onConfirm={handleConfirmTokenWarning}
       />
 
-      <SwapWrapper>
+      <SwapWrapper style={widgetBackground ? { backgroundColor: widgetBackground } : {}}>
         <Box p={10}>
           {isAEBToken && <DeprecatedWarning />}
-
           <CurrencyInputTextBox
             label={independentField === Field.OUTPUT && !showWrap && trade ? 'From (estimated)' : 'From'}
             value={formattedAmounts[Field.INPUT]}
@@ -495,6 +573,16 @@ const MarketOrder: React.FC<Props> = ({
             placeholder="0.00"
             id="swap-currency-input"
             addonLabel={renderPercentage()}
+            textPrimaryColor={textPrimaryColor}
+            textSecondaryColor={textSecondaryColor}
+            selectPrimaryBgColor={selectPrimaryBgColor}
+            selectSecondaryBgColor={selectSecondaryBgColor}
+            inputFieldBgColor={inputFieldBgColor}
+            style={
+              inputFieldBgColor && textSecondaryColor
+                ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                : {}
+            }
           />
 
           <Box width="100%" textAlign="center" alignItems="center" display="flex" justifyContent={'center'} mt={10}>
@@ -504,7 +592,7 @@ const MarketOrder: React.FC<Props> = ({
                 onSwitchTokens();
               }}
             >
-              <RefreshCcw size="16" color={theme.text4} />
+              <RefreshCcw size="16" color={textSecondaryColor ? textSecondaryColor : theme.text4} />
             </ArrowWrapper>
           </Box>
 
@@ -526,10 +614,20 @@ const MarketOrder: React.FC<Props> = ({
             id="swap-currency-output"
             addonLabel={
               tradePrice && (
-                <Text color="text4" fontSize={16}>
+                <Text color="text4" fontSize={16} style={textSecondaryColor ? { color: textSecondaryColor } : {}}>
                   Price: {tradePrice?.toSignificant(6)} {tradePrice?.quoteCurrency?.symbol}
                 </Text>
               )
+            }
+            textPrimaryColor={textPrimaryColor}
+            textSecondaryColor={textSecondaryColor}
+            selectPrimaryBgColor={selectPrimaryBgColor}
+            selectSecondaryBgColor={selectSecondaryBgColor}
+            inputFieldBgColor={inputFieldBgColor}
+            style={
+              inputFieldBgColor && textSecondaryColor
+                ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                : {}
             }
           />
 
@@ -538,7 +636,7 @@ const MarketOrder: React.FC<Props> = ({
               <LinkStyledButton
                 id="add-recipient-button"
                 onClick={() => onChangeRecipient('')}
-                style={{ alignSelf: 'end' }}
+                style={textPrimaryColor ? { alignSelf: 'end', color: textPrimaryColor } : { alignSelf: 'end' }}
               >
                 + Add Recipient
               </LinkStyledButton>
@@ -550,7 +648,7 @@ const MarketOrder: React.FC<Props> = ({
               <LinkStyledButton
                 id="add-recipient-button"
                 onClick={() => onChangeRecipient(null)}
-                style={{ alignSelf: 'end' }}
+                style={textPrimaryColor ? { alignSelf: 'end', color: textPrimaryColor } : { alignSelf: 'end' }}
               >
                 - Remove Recipient
               </LinkStyledButton>
@@ -562,12 +660,32 @@ const MarketOrder: React.FC<Props> = ({
                   const withoutSpaces = value.replace(/\s+/g, '');
                   onChangeRecipient(withoutSpaces);
                 }}
-                addonLabel={recipient && !isAddress(recipient) && <Text color="text1">Invalid Address</Text>}
+                addonLabel={
+                  recipient &&
+                  !isAddress(recipient) && (
+                    <Text color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
+                      Invalid Address
+                    </Text>
+                  )
+                }
+                textSecondaryColor={textSecondaryColor}
+                inputFieldBgColor={inputFieldBgColor}
+                style={
+                  inputFieldBgColor && textSecondaryColor
+                    ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                    : {}
+                }
               />
             </Box>
           ) : null}
 
-          {trade && <SwapDetailInfo trade={trade} />}
+          {trade && (
+            <SwapDetailInfo
+              trade={trade}
+              textSecondaryColor={textSecondaryColor}
+              inputFieldBgColor={inputFieldBgColor}
+            />
+          )}
 
           <Box width="100%" mt={10}>
             {renderButton()}
@@ -575,7 +693,7 @@ const MarketOrder: React.FC<Props> = ({
         </Box>
       </SwapWrapper>
 
-      {trade && showRoute && <SwapRoute trade={trade} />}
+      {trade && showRoute && <SwapRoute trade={trade} textPrimaryColor={textPrimaryColor} />}
       {/* Retries Drawer */}
       {/* <RetryDrawer isOpen={isRetryDrawerOpen} onClose={() => setIsRetryDrawerOpen(false)} /> */}
       {/* Token Drawer */}
@@ -587,6 +705,13 @@ const MarketOrder: React.FC<Props> = ({
           onCurrencySelect={onCurrencySelect}
           selectedCurrency={tokenDrawerType === Field.INPUT ? inputCurrency : outputCurrency}
           otherSelectedCurrency={tokenDrawerType === Field.INPUT ? outputCurrency : inputCurrency}
+          widgetBackground={widgetBackground}
+          textPrimaryColor={textPrimaryColor}
+          textSecondaryColor={textSecondaryColor}
+          inputFieldBgColor={inputFieldBgColor}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+          switchOnHandleColor={switchOnHandleColor}
         />
       )}
 
@@ -604,6 +729,12 @@ const MarketOrder: React.FC<Props> = ({
           onConfirm={handleSwap}
           swapErrorMessage={swapErrorMessage}
           onClose={handleConfirmDismiss}
+          widgetBackground={widgetBackground}
+          textPrimaryColor={textPrimaryColor}
+          textSecondaryColor={textSecondaryColor}
+          inputFieldBgColor={inputFieldBgColor}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
         />
       )}
     </Root>

--- a/src/components/SwapWidget/SelectTokenDrawer/CurrencyRow.tsx
+++ b/src/components/SwapWidget/SelectTokenDrawer/CurrencyRow.tsx
@@ -12,10 +12,11 @@ interface Props {
   onSelect: (currency: Currency) => void;
   isSelected: boolean;
   otherSelected: boolean;
+  textPrimaryColor?: string;
 }
 
 const CurrencyRow: React.FC<Props> = (props) => {
-  const { currency, style, onSelect, isSelected, otherSelected } = props;
+  const { currency, style, onSelect, isSelected, otherSelected, textPrimaryColor } = props;
   const { account } = usePangolinWeb3();
   const chainId = useChainId();
 
@@ -28,10 +29,15 @@ const CurrencyRow: React.FC<Props> = (props) => {
   return (
     <CurrencyRowRoot style={style} onClick={handleSelect} disabled={isSelected} selected={otherSelected}>
       <CurrencyLogo currency={currency} size={24} imageSize={48} />
-      <Text color="text1" fontSize={14} title={currency?.name}>
+      <Text
+        color="text1"
+        fontSize={14}
+        title={currency?.name}
+        style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+      >
         {currency?.symbol}
       </Text>
-      <Balance color="text1" fontSize={14}>
+      <Balance color="text1" fontSize={14} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
         {balance ? balance.toSignificant(4) : account ? <LoaderIcon /> : null}
       </Balance>
     </CurrencyRowRoot>

--- a/src/components/SwapWidget/SelectTokenDrawer/index.tsx
+++ b/src/components/SwapWidget/SelectTokenDrawer/index.tsx
@@ -22,6 +22,13 @@ interface Props {
   onCurrencySelect: (currency: Currency) => void;
   selectedCurrency?: Currency;
   otherSelectedCurrency?: Currency;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  inputFieldBgColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  switchOnHandleColor?: string;
 }
 
 const currencyKey = (currency: Currency, chainId: ChainId): string => {
@@ -29,7 +36,20 @@ const currencyKey = (currency: Currency, chainId: ChainId): string => {
 };
 
 const SelectTokenDrawer: React.FC<Props> = (props) => {
-  const { isOpen, onClose, onCurrencySelect, otherSelectedCurrency, selectedCurrency } = props;
+  const {
+    isOpen,
+    onClose,
+    onCurrencySelect,
+    otherSelectedCurrency,
+    selectedCurrency,
+    widgetBackground,
+    textPrimaryColor,
+    textSecondaryColor,
+    inputFieldBgColor,
+    btnPrimaryBgColor,
+    btnPrimaryTextColor,
+    switchOnHandleColor,
+  } = props;
   const [searchQuery, setSearchQuery] = useState<string>('');
   const [isTokenListOpen, setIsTokenListOpen] = useState<boolean>(false);
   const [invertSearchOrder] = useState<boolean>(false);
@@ -118,6 +138,7 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
           isSelected={isSelected}
           onSelect={onSelect}
           otherSelected={otherSelected}
+          textPrimaryColor={textPrimaryColor}
         />
       ) : null;
     },
@@ -126,9 +147,16 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
   );
 
   return (
-    <Drawer title="Select a token" isOpen={isOpen} onClose={onClose}>
+    <Drawer
+      title="Select a token"
+      isOpen={isOpen}
+      onClose={onClose}
+      widgetBackground={widgetBackground}
+      textPrimaryColor={textPrimaryColor}
+      textSecondaryColor={textSecondaryColor}
+    >
       {/* Render Search Token Input */}
-      <Box padding="0px 10px">
+      <Box padding="0px 10px" style={widgetBackground ? { backgroundColor: widgetBackground } : {}}>
         <TextInput
           placeholder="Search"
           onChange={(value: any) => {
@@ -141,10 +169,17 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
               inputRef.current?.scrollIntoView({ behavior: 'smooth' });
             }
           }}
+          textSecondaryColor={textSecondaryColor}
+          inputFieldBgColor={inputFieldBgColor}
+          style={
+            inputFieldBgColor && textSecondaryColor
+              ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+              : {}
+          }
         />
       </Box>
       {/* Render All Selected Tokens */}
-      <CurrencyList>
+      <CurrencyList style={widgetBackground ? { backgroundColor: widgetBackground } : {}}>
         <AutoSizer disableWidth>
           {({ height }) => (
             <FixedSizeList
@@ -164,10 +199,10 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
       <ManageList onClick={() => setIsTokenListOpen(true)}>
         {selectedListInfo.multipleSelected ? (
           <Box display="flex" justifyContent="space-between" alignItems="center" width="100%">
-            <Text fontSize={14} color="text1">
+            <Text fontSize={14} color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               {selectedListInfo.selectedCount} lists selected
             </Text>
-            <Text fontSize={12} color="text1">
+            <Text fontSize={12} color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               Change
             </Text>
           </Box>
@@ -179,18 +214,28 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
                 src={selectedListInfo?.current?.logoURI}
                 alt={`${selectedListInfo?.current?.name} list logo`}
               />
-              <Text fontSize={14} color="text1">
+              <Text fontSize={14} color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
                 {selectedListInfo?.current?.name}
               </Text>
             </Box>
-            <Text fontSize={12} color="text1">
+            <Text fontSize={12} color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
               Change
             </Text>
           </Box>
         )}
       </ManageList>
       {/* Render Token List Selection Drawer */}
-      <TokenListDrawer isOpen={isTokenListOpen} onClose={() => setIsTokenListOpen(false)} />
+      <TokenListDrawer
+        isOpen={isTokenListOpen}
+        onClose={() => setIsTokenListOpen(false)}
+        widgetBackground={widgetBackground}
+        textPrimaryColor={textPrimaryColor}
+        textSecondaryColor={textSecondaryColor}
+        inputFieldBgColor={inputFieldBgColor}
+        btnPrimaryBgColor={btnPrimaryBgColor}
+        btnPrimaryTextColor={btnPrimaryTextColor}
+        switchOnHandleColor={switchOnHandleColor}
+      />
     </Drawer>
   );
 };

--- a/src/components/SwapWidget/Settings/index.tsx
+++ b/src/components/SwapWidget/Settings/index.tsx
@@ -16,9 +16,30 @@ import { Frame, InputOptions } from './styled';
 interface Props {
   isOpen: boolean;
   close: () => void;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  inputFieldBgColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  toggleBgColor?: string;
+  toggleSelectedColor?: string;
+  toggleTextColor?: string;
 }
 
-const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
+const SwapSettingsDrawer: React.FC<Props> = ({
+  isOpen,
+  close,
+  widgetBackground,
+  textPrimaryColor,
+  textSecondaryColor,
+  inputFieldBgColor,
+  btnPrimaryBgColor,
+  btnPrimaryTextColor,
+  toggleBgColor,
+  toggleSelectedColor,
+  toggleTextColor,
+}) => {
   const theme = useContext(ThemeContext);
 
   const [userExpertMode, setUserExpertMode] = useExpertModeManager();
@@ -72,12 +93,21 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
   }, [expertMode, slippageTolerance]);
 
   return (
-    <Drawer title="Settings" isOpen={isOpen} onClose={close}>
+    <Drawer
+      title="Settings"
+      isOpen={isOpen}
+      onClose={close}
+      widgetBackground={widgetBackground}
+      textPrimaryColor={textPrimaryColor}
+      textSecondaryColor={textSecondaryColor}
+    >
       <WarningModal isOpen={modalOpen} close={() => setModalOpen(false)} setExpertMode={setExpertMode} />
       <Frame>
         {/*SLIPPAGE INPUT */}
         <Box height="90px">
-          <Text color="text1">Slippage</Text>
+          <Text color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
+            Slippage
+          </Text>
           <InputOptions>
             <TextInput
               value={slippageTolerance}
@@ -91,6 +121,13 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
               onChange={(value) => {
                 setSlippageTolerance(value);
               }}
+              textSecondaryColor={textSecondaryColor}
+              inputFieldBgColor={inputFieldBgColor}
+              style={
+                inputFieldBgColor && textSecondaryColor
+                  ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                  : {}
+              }
             />
             <NumberOptions
               options={[0.1, 0.5, 1]}
@@ -99,20 +136,37 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
               variant="box"
               onChange={(number) => setSlippageTolerance(number.toString())}
               isDisabled={false}
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              btnPrimaryTextColor={btnPrimaryTextColor}
             />
           </InputOptions>
           {Number(slippageTolerance) <= 0.1 && (
-            <Text color="text1" fontSize={12} marginBottom={10}>
+            <Text
+              color="text1"
+              fontSize={12}
+              marginBottom={10}
+              style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+            >
               Your transaction may fail
             </Text>
           )}
           {Number(slippageTolerance) > 50 && !expertMode ? (
-            <Text color="text12" fontSize="10px" marginBottom={10}>
+            <Text
+              color="text12"
+              fontSize="10px"
+              marginBottom={10}
+              style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+            >
               Very high slippage, activate expert mode to be able to use more than 50%
             </Text>
           ) : (
             Number(slippageTolerance) > 5 && (
-              <Text color="yellow2" fontSize={12} marginBottom={10}>
+              <Text
+                color="yellow2"
+                fontSize={12}
+                marginBottom={10}
+                style={textPrimaryColor ? { color: textPrimaryColor } : {}}
+              >
                 Your transaction may be frontrun
               </Text>
             )
@@ -120,7 +174,9 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
         </Box>
         {/*DEADLINE INPUT */}
         <Box height="90px">
-          <Text color="text1">Time Limit</Text>
+          <Text color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
+            Time Limit
+          </Text>
           <InputOptions>
             <TextInput
               value={deadline}
@@ -132,6 +188,13 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
               isNumeric={true}
               placeholder="10"
               onChange={(number) => setDeadline(number.toString())}
+              textSecondaryColor={textSecondaryColor}
+              inputFieldBgColor={inputFieldBgColor}
+              style={
+                inputFieldBgColor && textSecondaryColor
+                  ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                  : {}
+              }
             />
             <NumberOptions
               options={[60, 300, 600]}
@@ -139,6 +202,8 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
               variant="box"
               onChange={(number) => setDeadline(number.toString())}
               isDisabled={false}
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              btnPrimaryTextColor={btnPrimaryTextColor}
             />
           </InputOptions>
           {Number(deadline) <= 1 && (
@@ -150,7 +215,9 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
         </Box>
         {/*EXPERT MODE INPUT */}
         <Box display="flex" flexDirection="row" alignItems="center" justifyContent="center" style={{ gap: '15px' }}>
-          <Text color="text1">Toggle Expert Mode</Text>
+          <Text color="text1" style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
+            Toggle Expert Mode
+          </Text>
           <Box width="120px">
             <ToggleButtons
               options={['ON', 'OFF']}
@@ -162,11 +229,20 @@ const SwapSettingsDrawer: React.FC<Props> = ({ isOpen, close }) => {
                   setExpertMode(false);
                 }
               }}
+              toggleBgColor={toggleBgColor}
+              toggleSelectedColor={toggleSelectedColor}
+              toggleTextColor={toggleTextColor}
             />
           </Box>
         </Box>
         <Box display="flex" flexDirection="column" alignContent="center" style={{ gap: '10px' }}>
-          <Button variant="primary" onClick={save} isDisabled={!isValidValues}>
+          <Button
+            variant="primary"
+            onClick={save}
+            isDisabled={!isValidValues}
+            btnPrimaryBgColor={btnPrimaryBgColor}
+            btnPrimaryTextColor={btnPrimaryTextColor}
+          >
             Save &amp; Close
           </Button>
           <Button variant="plain" backgroundColor={theme.bg6} onClick={close} color="text1">

--- a/src/components/SwapWidget/SwapDetailInfo/index.tsx
+++ b/src/components/SwapWidget/SwapDetailInfo/index.tsx
@@ -8,9 +8,9 @@ import { useDaasFeeInfo } from '../../../state/pswap/hooks';
 import { Text } from '../../Text';
 import { ContentBox, DataBox, ValueText } from './styled';
 
-type Props = { trade: Trade };
+type Props = { trade: Trade; textSecondaryColor?: string; inputFieldBgColor?: string };
 
-const SwapDetailInfo: React.FC<Props> = ({ trade }) => {
+const SwapDetailInfo: React.FC<Props> = ({ trade, textSecondaryColor, inputFieldBgColor }) => {
   const [allowedSlippage] = useUserSlippageTolerance();
   const [feeInfo] = useDaasFeeInfo();
   const { priceImpactWithoutFee, realizedLPFee, realizedLPFeeAmount } = computeTradePriceBreakdown(trade);
@@ -37,11 +37,15 @@ const SwapDetailInfo: React.FC<Props> = ({ trade }) => {
   const renderRow = (label: string, value: string, showSeverity?: boolean) => {
     return (
       <DataBox key={label}>
-        <Text color="text4" fontSize={14}>
+        <Text color="text4" fontSize={14} style={textSecondaryColor ? { color: textSecondaryColor } : {}}>
           {label}
         </Text>
 
-        <ValueText fontSize={14} severity={showSeverity ? warningSeverity(priceImpactWithoutFee) : -1}>
+        <ValueText
+          fontSize={14}
+          severity={showSeverity ? warningSeverity(priceImpactWithoutFee) : -1}
+          style={textSecondaryColor && !showSeverity ? { color: textSecondaryColor } : {}}
+        >
           {value}
         </ValueText>
       </DataBox>
@@ -49,7 +53,7 @@ const SwapDetailInfo: React.FC<Props> = ({ trade }) => {
   };
 
   return (
-    <ContentBox>
+    <ContentBox style={inputFieldBgColor ? { backgroundColor: inputFieldBgColor } : {}}>
       {allowedSlippage !== INITIAL_ALLOWED_SLIPPAGE && renderRow('Slippage tolerance', `${allowedSlippage / 100}%`)}
       {renderRow(isExactIn ? 'Minimum Received' : 'Maximum Sold', amount)}
       {renderRow('Price Impact', priceImpact, true)}

--- a/src/components/SwapWidget/SwapRoute/index.tsx
+++ b/src/components/SwapWidget/SwapRoute/index.tsx
@@ -7,9 +7,10 @@ import { SwapRouteWrapper } from './styled';
 
 type Props = {
   trade: Trade;
+  textPrimaryColor?: string;
 };
 
-const SwapRoute: React.FC<Props> = ({ trade }) => {
+const SwapRoute: React.FC<Props> = ({ trade, textPrimaryColor }) => {
   const theme = useContext(ThemeContext);
   return (
     <SwapRouteWrapper>
@@ -21,12 +22,14 @@ const SwapRoute: React.FC<Props> = ({ trade }) => {
             <Box display="flex" alignItems="center" my={'5px'}>
               <CurrencyLogo currency={token} size={24} />
               <Box ml={'10px'}>
-                <Text fontSize={14} color={'text1'}>
+                <Text fontSize={14} color={'text1'} style={textPrimaryColor ? { color: textPrimaryColor } : {}}>
                   {token.symbol}
                 </Text>
               </Box>
             </Box>
-            {isLastItem ? null : <ChevronRight color={theme.text2} />}
+            {isLastItem ? null : (
+              <ChevronRight color={theme.text2} style={textPrimaryColor ? { stroke: textPrimaryColor } : {}} />
+            )}
           </Box>
         );
       })}

--- a/src/components/SwapWidget/TokenListDrawer/TokenListRow.tsx
+++ b/src/components/SwapWidget/TokenListDrawer/TokenListRow.tsx
@@ -12,9 +12,12 @@ import { DownArrow, ListLogo, PopoverContainer, RowRoot, Separator, ViewLink } f
 
 interface Props {
   listUrl: string;
+  textPrimaryColor?: string;
+  btnPrimaryBgColor?: string;
+  switchOnHandleColor?: string;
 }
 
-const TokenListRow: React.FC<Props> = ({ listUrl }) => {
+const TokenListRow: React.FC<Props> = ({ listUrl, textPrimaryColor, switchOnHandleColor }) => {
   const lists = useSelector<AppState['plists']['byUrl']>((state) => state.plists.byUrl);
   const { current: list } = lists[listUrl];
 
@@ -70,7 +73,15 @@ const TokenListRow: React.FC<Props> = ({ listUrl }) => {
     <RowRoot>
       {list?.logoURI ? <ListLogo size={24} src={list?.logoURI} /> : <ListLogo as="div" size={24} />}
       <Box>
-        <Text fontSize={16} color="text1" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        <Text
+          fontSize={16}
+          color="text1"
+          style={
+            textPrimaryColor
+              ? { color: textPrimaryColor, overflow: 'hidden', textOverflow: 'ellipsis' }
+              : { overflow: 'hidden', textOverflow: 'ellipsis' }
+          }
+        >
           {list?.name}
         </Text>
         <Text fontSize={12} color="text3" style={{ overflow: 'hidden', textOverflow: 'ellipsis' }} title={listUrl}>
@@ -79,7 +90,7 @@ const TokenListRow: React.FC<Props> = ({ listUrl }) => {
       </Box>
       <Box ref={node as any}>
         <DownArrow onClick={() => setOpen(!open)}>
-          <ChevronDown />
+          <ChevronDown style={textPrimaryColor ? { color: textPrimaryColor } : {}} />
         </DownArrow>
         {open && (
           <PopoverContainer>
@@ -100,7 +111,7 @@ const TokenListRow: React.FC<Props> = ({ listUrl }) => {
           </PopoverContainer>
         )}
       </Box>
-      <Switch checked={isSelected} onChange={() => selectThisList()} />
+      <Switch checked={isSelected} onChange={() => selectThisList()} switchOnHandleColor={switchOnHandleColor} />
     </RowRoot>
   );
 };

--- a/src/components/SwapWidget/TokenListDrawer/index.tsx
+++ b/src/components/SwapWidget/TokenListDrawer/index.tsx
@@ -14,9 +14,26 @@ import { AddInputWrapper, List } from './styled';
 interface Props {
   isOpen: boolean;
   onClose: () => void;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  inputFieldBgColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  switchOnHandleColor?: string;
 }
 
-const TokenListDrawer: React.FC<Props> = ({ isOpen, onClose }) => {
+const TokenListDrawer: React.FC<Props> = ({
+  isOpen,
+  onClose,
+  widgetBackground,
+  textPrimaryColor,
+  textSecondaryColor,
+  inputFieldBgColor,
+  btnPrimaryBgColor,
+  btnPrimaryTextColor,
+  switchOnHandleColor,
+}) => {
   const [listUrlInput, setListUrlInput] = useState<string>('');
   const dispatch = useDispatch();
   const lists = useSelector<AppState['plists']['byUrl']>((state) => state.plists.byUrl);
@@ -86,7 +103,14 @@ const TokenListDrawer: React.FC<Props> = ({ isOpen, onClose }) => {
   }, [lists]);
 
   return (
-    <Drawer title="Manage Lists" isOpen={isOpen} onClose={onClose}>
+    <Drawer
+      title="Manage Lists"
+      isOpen={isOpen}
+      onClose={onClose}
+      widgetBackground={widgetBackground}
+      textPrimaryColor={textPrimaryColor}
+      textSecondaryColor={textSecondaryColor}
+    >
       {/* Render Search Token Input */}
       <Box padding="0px 10px">
         <AddInputWrapper>
@@ -98,8 +122,23 @@ const TokenListDrawer: React.FC<Props> = ({ isOpen, onClose }) => {
             }}
             onKeyDown={handleEnterKey}
             value={listUrlInput}
+            textSecondaryColor={textSecondaryColor}
+            inputFieldBgColor={inputFieldBgColor}
+            style={
+              inputFieldBgColor && textSecondaryColor
+                ? { backgroundColor: inputFieldBgColor, color: textSecondaryColor }
+                : {}
+            }
           />
-          <Button variant="primary" padding={'0px'} isDisabled={!validUrl} onClick={handleAddList} height="50px">
+          <Button
+            variant="primary"
+            padding={'0px'}
+            isDisabled={!validUrl}
+            onClick={handleAddList}
+            height="50px"
+            btnPrimaryBgColor={btnPrimaryBgColor}
+            btnPrimaryTextColor={btnPrimaryTextColor}
+          >
             Add
           </Button>
         </AddInputWrapper>
@@ -113,7 +152,13 @@ const TokenListDrawer: React.FC<Props> = ({ isOpen, onClose }) => {
       <Scrollbars>
         <List>
           {sortedLists.map((url) => (
-            <TokenListRow listUrl={url} key={url} />
+            <TokenListRow
+              listUrl={url}
+              key={url}
+              textPrimaryColor={textPrimaryColor}
+              btnPrimaryBgColor={btnPrimaryBgColor}
+              switchOnHandleColor={switchOnHandleColor}
+            />
           ))}
         </List>
       </Scrollbars>

--- a/src/components/SwapWidget/TradeOption/index.tsx
+++ b/src/components/SwapWidget/TradeOption/index.tsx
@@ -10,6 +10,13 @@ interface Props {
   isLimitOrderVisible: boolean;
   showSettings?: boolean;
   openSwapSettings?: () => void;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  btnDisabledBgColor?: string;
+  settingsBtnBgColor?: string;
+  toggleBgColor?: string;
+  toggleSelectedColor?: string;
+  toggleTextColor?: string;
 }
 
 const TradeOption: React.FC<Props> = ({
@@ -18,29 +25,42 @@ const TradeOption: React.FC<Props> = ({
   isLimitOrderVisible,
   showSettings = false,
   openSwapSettings = () => {},
+  widgetBackground,
+  textPrimaryColor,
+  btnDisabledBgColor,
+  settingsBtnBgColor,
+  toggleBgColor,
+  toggleSelectedColor,
+  toggleTextColor,
 }) => {
   return (
-    <SwapWrapper>
+    <SwapWrapper style={widgetBackground ? { backgroundColor: widgetBackground } : {}}>
       {/* <SwapAlertBox>This is a BETA release and should be used at your own risk!</SwapAlertBox> */}
 
       <Box p={10}>
         <Box display="flex" alignItems="center" style={{ gap: '6px' }}>
-          <Text color="text1" fontSize={24} fontWeight={500} style={{ flexGrow: 1 }}>
+          <Text color="text1" fontSize={24} fontWeight={500} style={{ flexGrow: 1, color: textPrimaryColor }}>
             Trade
           </Text>
           {showSettings && swapType === 'MARKET' && (
-            <SettingsButton onClick={openSwapSettings}>
+            <SettingsButton
+              onClick={openSwapSettings}
+              style={settingsBtnBgColor ? { backgroundColor: settingsBtnBgColor } : {}}
+            >
               <Settings size={20} />
             </SettingsButton>
           )}
           {isLimitOrderVisible && (
-            <Box width="130px">
+            <Box width="130px" style={btnDisabledBgColor ? { background: btnDisabledBgColor } : {}}>
               <ToggleButtons
                 options={['MARKET', 'LIMIT']}
                 value={swapType}
                 onChange={(value) => {
                   setSwapType(value);
                 }}
+                toggleBgColor={toggleBgColor}
+                toggleSelectedColor={toggleSelectedColor}
+                toggleTextColor={toggleTextColor}
               />
             </Box>
           )}

--- a/src/components/SwapWidget/TradeOption/styled.tsx
+++ b/src/components/SwapWidget/TradeOption/styled.tsx
@@ -4,7 +4,6 @@ import { Box } from '../../';
 export const SwapWrapper = styled(Box)`
   width: 100%;
   /* min-width: 400px; */
-  background-color: ${({ theme }) => theme.color2};
   position: relative;
   overflow: hidden;
   border-top-left-radius: 10px;

--- a/src/components/SwapWidget/index.tsx
+++ b/src/components/SwapWidget/index.tsx
@@ -8,12 +8,44 @@ export interface Props {
   isLimitOrderVisible?: boolean;
   showSettings?: boolean;
   partnerDaaS?: string;
+  widgetBackground?: string;
+  textPrimaryColor?: string;
+  textSecondaryColor?: string;
+  btnPrimaryBgColor?: string;
+  btnPrimaryTextColor?: string;
+  btnConfirmedBgColor?: string;
+  btnConfirmedTextColor?: string;
+  btnDisabledBgColor?: string;
+  btnDisabledTextColor?: string;
+  settingsBtnBgColor?: string;
+  selectPrimaryBgColor?: string;
+  selectSecondaryBgColor?: string;
+  toggleBgColor?: string;
+  toggleSelectedColor?: string;
+  toggleTextColor?: string;
+  inputFieldBgColor?: string;
+  switchOnHandleColor?: string;
 }
 
 const SwapWidget: React.FC<Props> = ({
   isLimitOrderVisible = false,
   showSettings = true,
   partnerDaaS = ZERO_ADDRESS,
+  widgetBackground,
+  textPrimaryColor,
+  textSecondaryColor,
+  btnPrimaryBgColor,
+  btnPrimaryTextColor,
+  btnConfirmedBgColor,
+  btnConfirmedTextColor,
+  settingsBtnBgColor,
+  selectPrimaryBgColor,
+  selectSecondaryBgColor,
+  toggleBgColor,
+  toggleSelectedColor,
+  toggleTextColor,
+  inputFieldBgColor,
+  switchOnHandleColor,
 }) => {
   const [swapType, setSwapType] = useState('MARKET' as string);
   return (
@@ -25,6 +57,20 @@ const SwapWidget: React.FC<Props> = ({
             setSwapType(type);
           }}
           isLimitOrderVisible={isLimitOrderVisible}
+          widgetBackground={widgetBackground}
+          textPrimaryColor={textPrimaryColor}
+          textSecondaryColor={textSecondaryColor}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+          btnConfirmedBgColor={btnConfirmedBgColor}
+          btnConfirmedTextColor={btnConfirmedTextColor}
+          settingsBtnBgColor={settingsBtnBgColor}
+          selectPrimaryBgColor={selectPrimaryBgColor}
+          selectSecondaryBgColor={selectSecondaryBgColor}
+          toggleBgColor={toggleBgColor}
+          toggleSelectedColor={toggleSelectedColor}
+          toggleTextColor={toggleTextColor}
+          inputFieldBgColor={inputFieldBgColor}
         />
       ) : (
         <MarketOrder
@@ -35,6 +81,21 @@ const SwapWidget: React.FC<Props> = ({
           isLimitOrderVisible={isLimitOrderVisible}
           showSettings={showSettings}
           partnerDaaS={partnerDaaS}
+          widgetBackground={widgetBackground}
+          textPrimaryColor={textPrimaryColor}
+          textSecondaryColor={textSecondaryColor}
+          btnPrimaryBgColor={btnPrimaryBgColor}
+          btnPrimaryTextColor={btnPrimaryTextColor}
+          btnConfirmedBgColor={btnConfirmedBgColor}
+          btnConfirmedTextColor={btnConfirmedTextColor}
+          settingsBtnBgColor={settingsBtnBgColor}
+          selectPrimaryBgColor={selectPrimaryBgColor}
+          selectSecondaryBgColor={selectSecondaryBgColor}
+          toggleBgColor={toggleBgColor}
+          toggleSelectedColor={toggleSelectedColor}
+          toggleTextColor={toggleTextColor}
+          inputFieldBgColor={inputFieldBgColor}
+          switchOnHandleColor={switchOnHandleColor}
         />
       )}
     </Root>

--- a/src/components/SwapWidget/swapWidget.stories.tsx
+++ b/src/components/SwapWidget/swapWidget.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory } from '@storybook/react';
 import React from 'react';
+import { defaultColors as theme } from '../../theme';
 import { Box } from '../Box';
 import SwapWidget from '.';
 
@@ -22,4 +23,19 @@ export const Default = TemplateSwapWidget.bind({});
 Default.args = {
   isLimitOrderVisible: false,
   showSettings: true,
+  widgetBackground: theme.bg2,
+  textPrimaryColor: theme.text1,
+  textSecondaryColor: theme.text4,
+  btnPrimaryBgColor: theme.primary,
+  btnPrimaryTextColor: theme.black,
+  btnConfirmedBgColor: theme.oceanBlue,
+  btnConfirmedTextColor: theme.oceanBlue,
+  settingsBtnBgColor: theme.platinum,
+  selectPrimaryBgColor: theme.primary,
+  selectSecondaryBgColor: theme.ghostWhite,
+  toggleBgColor: theme.platinum,
+  toggleSelectedColor: theme.ghostWhite,
+  toggleTextColor: theme.chineseBlack,
+  inputFieldBgColor: theme.bg1,
+  switchOnHandleColor: theme?.switch?.onColor,
 };

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -20,6 +20,7 @@ const Switch: React.FC<SwitchProps> = (props) => {
     onHandleColor,
     uncheckedIcon,
     width,
+    switchOnHandleColor,
   } = props;
   const theme = useTheme();
 
@@ -27,7 +28,7 @@ const Switch: React.FC<SwitchProps> = (props) => {
     <BaseSwitch
       checked={checked}
       onChange={(isChecked) => onChange?.(isChecked)}
-      onHandleColor={onHandleColor || theme.switch?.onColor}
+      onHandleColor={switchOnHandleColor ? switchOnHandleColor : onHandleColor || theme.switch?.onColor}
       offHandleColor={offHandleColor || theme.switch?.offColor}
       onColor={onColor || theme.switch?.backgroundColor}
       offColor={offColor || theme.switch?.backgroundColor}

--- a/src/components/Switch/types.tsx
+++ b/src/components/Switch/types.tsx
@@ -10,4 +10,5 @@ export type SwitchProps = {
   checkedIcon?: React.ReactElement | boolean;
   height?: number;
   width?: number;
+  switchOnHandleColor?: string;
 };

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -16,6 +16,8 @@ const TextInput: React.FC<TextInputProps> = (props) => {
     isNumeric,
     getRef = () => {},
     autoComplete = 'off',
+    textSecondaryColor,
+    inputFieldBgColor,
     ...rest
   } = props;
 
@@ -24,10 +26,14 @@ const TextInput: React.FC<TextInputProps> = (props) => {
   return (
     <Box>
       <Box display="flex" justifyContent={label ? 'space-between' : 'flex-end'}>
-        {label && <Text color="text4">{label}</Text>}
+        {label && (
+          <Text color="text4" style={textSecondaryColor ? { color: textSecondaryColor } : {}}>
+            {label}
+          </Text>
+        )}
         {addonLabel && addonLabel}
       </Box>
-      <InputWrapper>
+      <InputWrapper style={inputFieldBgColor ? { backgroundColor: inputFieldBgColor } : {}}>
         {addonBefore && <AddonBefore>{addonBefore}</AddonBefore>}
         <StyledInput
           {...(rest as any)}

--- a/src/components/TextInput/types.tsx
+++ b/src/components/TextInput/types.tsx
@@ -21,4 +21,6 @@ export type TextInputProps = Omit<React.HTMLProps<HTMLInputElement>, 'accept' | 
   isNumeric?: boolean;
   onChange?: (value: string) => void;
   getRef?: (ref: any) => void;
+  textSecondaryColor?: string;
+  inputFieldBgColor?: string;
 };

--- a/src/components/ToggleButtons/ToggleButtons.tsx
+++ b/src/components/ToggleButtons/ToggleButtons.tsx
@@ -3,10 +3,10 @@ import { Root, TextButton } from './styles';
 import { ToggleButtonsProps } from './types';
 
 const ToggleButtons: React.FC<ToggleButtonsProps> = (props) => {
-  const { value, onChange, options } = props;
+  const { value, onChange, options, toggleBgColor, toggleSelectedColor, toggleTextColor } = props;
 
   return (
-    <Root>
+    <Root style={toggleBgColor ? { background: toggleBgColor } : {}}>
       {(options || []).map((option, i) => (
         <TextButton
           key={i}
@@ -14,6 +14,13 @@ const ToggleButtons: React.FC<ToggleButtonsProps> = (props) => {
           onClick={() => {
             onChange && onChange(option);
           }}
+          style={
+            toggleBgColor && toggleSelectedColor && toggleTextColor
+              ? option === value
+                ? { background: toggleSelectedColor, color: toggleTextColor }
+                : { background: toggleBgColor, color: toggleTextColor }
+              : {}
+          }
         >
           {option}
         </TextButton>

--- a/src/components/ToggleButtons/types.tsx
+++ b/src/components/ToggleButtons/types.tsx
@@ -7,4 +7,7 @@ export type ToggleButtonsProps = {
   value?: any;
   size?: number;
   options: Array<string>;
+  toggleBgColor?: string;
+  toggleSelectedColor?: string;
+  toggleTextColor?: string;
 };


### PR DESCRIPTION
**Custom CSS - Swap widget**
1. Added following props to swap widget to allow tweaking the widget UI as needed:
-   widgetBackground
-   textPrimaryColor
-   textSecondaryColor
-   btnPrimaryBgColor
-   btnPrimaryTextColor
-   btnConfirmedBgColor
-   btnConfirmedTextColor
-   settingsBtnBgColor
-   selectPrimaryBgColor
-   selectSecondaryBgColor
-   toggleBgColor
-   toggleSelectedColor
-   toggleTextColor
-   inputFieldBgColor
-   switchOnHandleColor

2. SwapWidget components and few external reusable components (Button, CurrencyInput, Drawer, Loader, NumberOptions, Switch, TextInput & ToggleButtons) adjusted as per it.