### PR TITLE
added defaultInputToken & defaultOutputToken props to swap widget

### DIFF
--- a/src/components/SwapWidget/LimitOrder/index.tsx
+++ b/src/components/SwapWidget/LimitOrder/index.tsx
@@ -175,9 +175,9 @@ const LimitOrder: React.FC<Props> = ({
 
   // setting default tokens
   const defaultInputToken = useToken(defaultInputAddress);
-  const defaultInputCurrency = unwrappedToken(defaultInputToken as Token, chainId);
+  const defaultInputCurrency = defaultInputToken ? unwrappedToken(defaultInputToken as Token, chainId) : undefined;
   const defaultOutputToken = useToken(defaultOutputAddress);
-  const defaultOutputCurrency = unwrappedToken(defaultOutputToken as Token, chainId);
+  const defaultOutputCurrency = defaultOutputToken ? unwrappedToken(defaultOutputToken as Token, chainId) : undefined;
 
   useEffect(() => {
     if (defaultInputCurrency) {

--- a/src/components/SwapWidget/LimitOrder/index.tsx
+++ b/src/components/SwapWidget/LimitOrder/index.tsx
@@ -50,7 +50,7 @@ const LimitOrder: React.FC<Props> = ({
   const [activeTab, setActiveTab] = useState<'SELL' | 'BUY'>('SELL');
   const { account } = usePangolinWeb3();
   const chainId = useChainId();
-  const useToken_ = useTokenHook[chainId];
+  const useToken = useTokenHook[chainId];
   const theme = useContext(ThemeContext);
 
   const percentageValue = [25, 50, 75, 100];
@@ -174,8 +174,10 @@ const LimitOrder: React.FC<Props> = ({
   );
 
   // setting default tokens
-  const defaultInputCurrency = unwrappedToken(useToken_(defaultInputAddress) as Token, chainId);
-  const defaultOutputCurrency = unwrappedToken(useToken_(defaultOutputAddress) as Token, chainId);
+  const defaultInputToken = useToken(defaultInputAddress);
+  const defaultInputCurrency = unwrappedToken(defaultInputToken as Token, chainId);
+  const defaultOutputToken = useToken(defaultOutputAddress);
+  const defaultOutputCurrency = unwrappedToken(defaultOutputToken as Token, chainId);
 
   useEffect(() => {
     if (defaultInputCurrency) {
@@ -184,7 +186,7 @@ const LimitOrder: React.FC<Props> = ({
     if (defaultOutputCurrency) {
       onCurrencySelect(defaultOutputCurrency, LimitNewField.OUTPUT);
     }
-  }, [chainId, defaultInputAddress, defaultOutputAddress]);
+  }, [chainId, defaultInputAddress, defaultOutputAddress, defaultInputCurrency, defaultOutputCurrency]);
 
   // modal and loading
   const [{ showConfirm, tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{
@@ -335,8 +337,9 @@ const LimitOrder: React.FC<Props> = ({
   }, [attemptingTxn, showConfirm, swapErrorMessage, trade, txHash]);
 
   const onCurrencySelect = useCallback(
-    (currency: any, tokenDrawerType?: LimitNewField) => {
-      if (tokenDrawerType === (LimitNewField.INPUT as any)) {
+    (currency: any, tokenDrawerTypeArg?: LimitNewField) => {
+      const type = tokenDrawerTypeArg ?? tokenDrawerType;
+      if (type === (LimitNewField.INPUT as any)) {
         setApprovalSubmitted(false); // reset 2 step UI for approvals
       }
 
@@ -348,9 +351,9 @@ const LimitOrder: React.FC<Props> = ({
         newCurrency.isToken = true;
       }
 
-      onCurrencySelection(tokenDrawerType as any, newCurrency);
+      onCurrencySelection(type as any, newCurrency);
       // this is to update tokens on chart on token selection
-      onSwapCurrencySelection(tokenDrawerType as any, currency);
+      onSwapCurrencySelection(type as any, currency);
     },
     [tokenDrawerType, onCurrencySelection, onSwapCurrencySelection],
   );

--- a/src/components/SwapWidget/MarketOrder/index.tsx
+++ b/src/components/SwapWidget/MarketOrder/index.tsx
@@ -174,9 +174,9 @@ const MarketOrder: React.FC<Props> = ({
 
   // setting default tokens
   const defaultInputToken = useToken(defaultInputAddress);
-  const defaultInputCurrency = unwrappedToken(defaultInputToken as Token, chainId);
+  const defaultInputCurrency = defaultInputToken ? unwrappedToken(defaultInputToken as Token, chainId) : undefined;
   const defaultOututToken = useToken(defaultOutputAddress);
-  const defaultOutputCurrency = unwrappedToken(defaultOututToken as Token, chainId);
+  const defaultOutputCurrency = defaultOututToken ? unwrappedToken(defaultOututToken as Token, chainId) : undefined;
 
   useEffect(() => {
     if (defaultInputCurrency) {

--- a/src/components/SwapWidget/MarketOrder/index.tsx
+++ b/src/components/SwapWidget/MarketOrder/index.tsx
@@ -91,7 +91,7 @@ const MarketOrder: React.FC<Props> = ({
 
   const { account } = usePangolinWeb3();
   const chainId = useChainId();
-  const useToken_ = useTokenHook[chainId];
+  const useToken = useTokenHook[chainId];
   const theme = useContext(ThemeContext);
   const useWrapCallback = useWrapCallbackHook[chainId];
   const useApproveCallbackFromTrade = useApproveCallbackFromTradeHook[chainId];
@@ -173,8 +173,10 @@ const MarketOrder: React.FC<Props> = ({
   );
 
   // setting default tokens
-  const defaultInputCurrency = unwrappedToken(useToken_(defaultInputAddress) as Token, chainId);
-  const defaultOutputCurrency = unwrappedToken(useToken_(defaultOutputAddress) as Token, chainId);
+  const defaultInputToken = useToken(defaultInputAddress);
+  const defaultInputCurrency = unwrappedToken(defaultInputToken as Token, chainId);
+  const defaultOututToken = useToken(defaultOutputAddress);
+  const defaultOutputCurrency = unwrappedToken(defaultOututToken as Token, chainId);
 
   useEffect(() => {
     if (defaultInputCurrency) {
@@ -183,7 +185,7 @@ const MarketOrder: React.FC<Props> = ({
     if (defaultOutputCurrency) {
       onCurrencySelection(Field.OUTPUT, defaultOutputCurrency);
     }
-  }, [chainId, defaultInputAddress, defaultOutputAddress]);
+  }, [chainId, defaultInputAddress, defaultOutputAddress, defaultInputCurrency, defaultOutputCurrency]);
 
   // modal and loading
   const [{ showConfirm, tradeToConfirm, swapErrorMessage, attemptingTxn, txHash }, setSwapState] = useState<{

--- a/src/components/SwapWidget/index.tsx
+++ b/src/components/SwapWidget/index.tsx
@@ -20,16 +20,6 @@ const SwapWidget: React.FC<Props> = ({
   defaultOutputToken,
 }) => {
   const [swapType, setSwapType] = useState('MARKET' as string);
-  const [defaultInputCurrency, setDefaultInputCurrency] = useState(defaultInputToken as string);
-  const [defaultOutputCurrency, setDefaultOutputCurrency] = useState(defaultOutputToken as string);
-
-  const updateDefaultInputCurrency = (value: string) => {
-    setDefaultInputCurrency(value);
-  };
-
-  const updateDefaultOutputCurrency = (value: string) => {
-    setDefaultOutputCurrency(value);
-  };
 
   return (
     <Root>
@@ -40,10 +30,8 @@ const SwapWidget: React.FC<Props> = ({
             setSwapType(type);
           }}
           isLimitOrderVisible={isLimitOrderVisible}
-          defaultInputCurrency={defaultInputCurrency}
-          defaultOutputCurrency={defaultOutputCurrency}
-          updateDefaultOutputCurrency={updateDefaultOutputCurrency}
-          updateDefaultInputCurrency={updateDefaultInputCurrency}
+          defaultInputAddress={defaultInputToken}
+          defaultOutputAddress={defaultOutputToken}
         />
       ) : (
         <MarketOrder
@@ -54,10 +42,8 @@ const SwapWidget: React.FC<Props> = ({
           isLimitOrderVisible={isLimitOrderVisible}
           showSettings={showSettings}
           partnerDaaS={partnerDaaS}
-          defaultInputCurrency={defaultInputCurrency}
-          defaultOutputCurrency={defaultOutputCurrency}
-          updateDefaultOutputCurrency={updateDefaultOutputCurrency}
-          updateDefaultInputCurrency={updateDefaultInputCurrency}
+          defaultInputAddress={defaultInputToken}
+          defaultOutputAddress={defaultOutputToken}
         />
       )}
     </Root>

--- a/src/components/SwapWidget/index.tsx
+++ b/src/components/SwapWidget/index.tsx
@@ -8,14 +8,29 @@ export interface Props {
   isLimitOrderVisible?: boolean;
   showSettings?: boolean;
   partnerDaaS?: string;
+  defaultInputToken?: string;
+  defaultOutputToken?: string;
 }
 
 const SwapWidget: React.FC<Props> = ({
   isLimitOrderVisible = false,
   showSettings = true,
   partnerDaaS = ZERO_ADDRESS,
+  defaultInputToken,
+  defaultOutputToken,
 }) => {
   const [swapType, setSwapType] = useState('MARKET' as string);
+  const [defaultInputCurrency, setDefaultInputCurrency] = useState(defaultInputToken as string);
+  const [defaultOutputCurrency, setDefaultOutputCurrency] = useState(defaultOutputToken as string);
+
+  const updateDefaultInputCurrency = (value: string) => {
+    setDefaultInputCurrency(value);
+  };
+
+  const updateDefaultOutputCurrency = (value: string) => {
+    setDefaultOutputCurrency(value);
+  };
+
   return (
     <Root>
       {swapType === 'LIMIT' ? (
@@ -25,6 +40,10 @@ const SwapWidget: React.FC<Props> = ({
             setSwapType(type);
           }}
           isLimitOrderVisible={isLimitOrderVisible}
+          defaultInputCurrency={defaultInputCurrency}
+          defaultOutputCurrency={defaultOutputCurrency}
+          updateDefaultOutputCurrency={updateDefaultOutputCurrency}
+          updateDefaultInputCurrency={updateDefaultInputCurrency}
         />
       ) : (
         <MarketOrder
@@ -35,6 +54,10 @@ const SwapWidget: React.FC<Props> = ({
           isLimitOrderVisible={isLimitOrderVisible}
           showSettings={showSettings}
           partnerDaaS={partnerDaaS}
+          defaultInputCurrency={defaultInputCurrency}
+          defaultOutputCurrency={defaultOutputCurrency}
+          updateDefaultOutputCurrency={updateDefaultOutputCurrency}
+          updateDefaultInputCurrency={updateDefaultInputCurrency}
         />
       )}
     </Root>

--- a/src/components/SwapWidget/swapWidget.stories.tsx
+++ b/src/components/SwapWidget/swapWidget.stories.tsx
@@ -22,4 +22,6 @@ export const Default = TemplateSwapWidget.bind({});
 Default.args = {
   isLimitOrderVisible: false,
   showSettings: true,
+  defaultInputToken: 'aave.e',
+  defaultOutputToken: 'aablock',
 };

--- a/src/components/SwapWidget/swapWidget.stories.tsx
+++ b/src/components/SwapWidget/swapWidget.stories.tsx
@@ -25,3 +25,11 @@ Default.args = {
   defaultInputToken: '',
   defaultOutputToken: '',
 };
+
+export const WithDefaultTokenValues = TemplateSwapWidget.bind({});
+WithDefaultTokenValues.args = {
+  isLimitOrderVisible: false,
+  showSettings: true,
+  defaultInputToken: '0x5947bb275c521040051d82396192181b413227a3',
+  defaultOutputToken: '0x60781c2586d68229fde47564546784ab3faca982',
+};

--- a/src/components/SwapWidget/swapWidget.stories.tsx
+++ b/src/components/SwapWidget/swapWidget.stories.tsx
@@ -22,6 +22,6 @@ export const Default = TemplateSwapWidget.bind({});
 Default.args = {
   isLimitOrderVisible: false,
   showSettings: true,
-  defaultInputToken: 'aave.e',
-  defaultOutputToken: 'aablock',
+  defaultInputToken: '',
+  defaultOutputToken: '',
 };


### PR DESCRIPTION
Users can pass token symbols as defaultInputToken & defaultOutputToken props (case insensitive) to swap widget. 
If match is found, that token is set. Otherwise, original default tokens will be set in place.