### PR TITLE
Fixed UI Bugs

### DIFF
--- a/src/components/Pools/AddLiquidity/PoolPriceBar/index.tsx
+++ b/src/components/Pools/AddLiquidity/PoolPriceBar/index.tsx
@@ -47,7 +47,7 @@ const PoolPriceBar = ({ currencies, noLiquidity, poolTokenPercentage, price, par
       <GridContainer>
         <Box>
           <Stat
-            title={`${t('migratePage.dollarWorth')}`}
+            title={`${t('migratePage.usd')}`}
             stat={sharePoolStat}
             titlePosition="top"
             titleFontSize={12}

--- a/src/components/Pools/AddLiquidity/index.tsx
+++ b/src/components/Pools/AddLiquidity/index.tsx
@@ -251,9 +251,7 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
             addonLabel={
               account && (
                 <Text color="text2" fontWeight={500} fontSize={12}>
-                  {!!currencyA && selectedCurrencyBalanceA
-                    ? t('currencyInputPanel.balance') + selectedCurrencyBalanceA?.toSignificant(6)
-                    : ' -'}
+                  {!!currencyA && selectedCurrencyBalanceA ? selectedCurrencyBalanceA?.toSignificant(4) : ' -'}
                 </Text>
               )
             }
@@ -295,9 +293,7 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
             addonLabel={
               account && (
                 <Text color="text2" fontWeight={500} fontSize={12}>
-                  {!!currencyB && selectedCurrencyBalanceB
-                    ? t('currencyInputPanel.balance') + selectedCurrencyBalanceB?.toSignificant(6)
-                    : ' -'}
+                  {!!currencyB && selectedCurrencyBalanceB ? selectedCurrencyBalanceB?.toSignificant(4) : ' -'}
                 </Text>
               )
             }

--- a/src/components/SarManageWidget/Title.tsx
+++ b/src/components/SarManageWidget/Title.tsx
@@ -33,7 +33,7 @@ export default function Title({ selectPosition, selectedOption, onChange }: Prop
   return (
     <Box display="flex" flexDirection="column">
       <Box display="flex" justifyContent={selectPosition ? 'space-between' : 'start'} alignItems="center">
-        <Text color="text1" fontSize="21px" fontWeight={700}>
+        <Text color="text1" fontSize="15.75px" fontWeight={700}>
           {renderTitle()}
         </Text>
         {selectPosition && (

--- a/src/components/SwapWidget/ConfirmSwapDrawer/index.tsx
+++ b/src/components/SwapWidget/ConfirmSwapDrawer/index.tsx
@@ -1,6 +1,7 @@
 import { Trade, TradeType } from '@pangolindex/sdk';
 import React, { useContext, useMemo } from 'react';
 import { AlertTriangle, ArrowDown, ArrowUpCircle } from 'react-feather';
+import { Trans } from 'react-i18next';
 import { ThemeContext } from 'styled-components';
 import Drawer from 'src/components/Drawer';
 import { usePangolinWeb3 } from 'src/hooks';
@@ -53,7 +54,6 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
 
   const { chainId } = usePangolinWeb3();
   const theme = useContext(ThemeContext);
-
   const slippageAdjustedAmounts = useMemo(
     () => computeSlippageAdjustedAmounts(trade, allowedSlippage),
     [trade, allowedSlippage],
@@ -122,19 +122,23 @@ const ConfirmSwapDrawer: React.FC<Props> = (props) => {
         <Box mt={'15px'}>
           {trade.tradeType === TradeType.EXACT_INPUT ? (
             <OutputText color="text2">
-              Output is estimated. You will receive at least
-              <b>
-                {slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(6)} {trade.outputAmount.currency.symbol}
-              </b>
-              or the transaction will revert.
+              <Trans
+                i18nKey="swap.outputEstimated"
+                values={{
+                  amount: slippageAdjustedAmounts[Field.OUTPUT]?.toSignificant(6),
+                  currencySymbol: trade.outputAmount.currency.symbol,
+                }}
+              />
             </OutputText>
           ) : (
             <OutputText color="text2">
-              Input is estimated. You will sell at most
-              <b>
-                {slippageAdjustedAmounts[Field.INPUT]?.toSignificant(6)} {trade.inputAmount.currency.symbol}
-              </b>
-              or the transaction will revert.
+              <Trans
+                i18nKey="swap.inputEstimated"
+                values={{
+                  amount: slippageAdjustedAmounts[Field.INPUT]?.toSignificant(6),
+                  currencySymbol: trade.inputAmount.currency.symbol,
+                }}
+              />
             </OutputText>
           )}
         </Box>

--- a/src/components/SwapWidget/LimitOrder/index.tsx
+++ b/src/components/SwapWidget/LimitOrder/index.tsx
@@ -564,14 +564,15 @@ const LimitOrder: React.FC<Props> = ({
         </Box>
       </SwapWrapper>
 
-      {/* Token Drawer */}
-      <SelectTokenDrawer
-        isOpen={isTokenDrawerOpen}
-        onClose={handleSelectTokenDrawerClose}
-        onCurrencySelect={onCurrencySelect}
-        selectedCurrency={tokenDrawerType === (LimitNewField.INPUT as any) ? inputCurrency : outputCurrency}
-        otherSelectedCurrency={tokenDrawerType === (LimitNewField.INPUT as any) ? outputCurrency : inputCurrency}
-      />
+      {isTokenDrawerOpen && (
+        <SelectTokenDrawer
+          isOpen={isTokenDrawerOpen}
+          onClose={handleSelectTokenDrawerClose}
+          onCurrencySelect={onCurrencySelect}
+          selectedCurrency={tokenDrawerType === (LimitNewField.INPUT as any) ? inputCurrency : outputCurrency}
+          otherSelectedCurrency={tokenDrawerType === (LimitNewField.INPUT as any) ? outputCurrency : inputCurrency}
+        />
+      )}
 
       {/* Confirm Swap Drawer */}
       {trade && (

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -33,6 +33,7 @@ const TextInput: React.FC<TextInputProps> = (props) => {
           {...(rest as any)}
           autoComplete={autoComplete}
           ref={(ref) => getRef(ref)}
+          type={isNumeric ? 'number' : 'text'}
           onChange={(e) => {
             const value = e.target.value;
 

--- a/src/components/TextInput/styles.tsx
+++ b/src/components/TextInput/styles.tsx
@@ -26,6 +26,12 @@ export const StyledInput = styled.input<TextInputProps>`
   outline: none;
   width: 100%;
   padding: 0;
+  -moz-appearance: textfield;
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
   ::placeholder {
     color: ${({ theme }) => theme.textInput?.placeholderText};
   }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -200,9 +200,8 @@
     "maximumSold": "Du verkaufst höchstens",
     "transactionRevertHelper": "Deine Transaktion wird storniert, wenn es eine große, ungünstige Preisbewegung gibt, bevor sie bestätigt wird.",
     "priceUpdated": "Preis aktualisiert",
-    "outputEstimated": "Die Kaufmenge ist geschätzt. Du erhältst mindestens ",
-    "transactionRevert": " oder die Transaktion wird storniert.",
-    "inputEstimated": "Die Verkaufsmenge ist geschätzt. Du verkaufst höchstens ",
+    "outputEstimated": "Die Kaufmenge ist geschätzt. Du erhältst mindestens <strong>{{amount}} {{currencySymbol}}</strong> oder die Transaktion wird storniert.",
+    "inputEstimated": "Die Verkaufsmenge ist geschätzt. Du verkaufst höchstens <strong>{{amount}} {{currencySymbol}}</strong> oder die Transaktion wird storniert.",
     "outputSentTo": "Die Verkaufsmenge wird gesendet an ",
     "priceImpactMinPrompt": "Dieser Tausch hat eine Preisauswirkung von mindestens {{ priceImpact }}%. Bitte gib das Wort \"bestätige\" ein, um mit dem Tausch fortzufahren.",
     "priceImpactHighPrompt": "Dieser Tausch hat eine Preisauswirkung von mindestens {{ priceImpact }}%. Bitte gib das Wort \"bestätige\" ein, um mit dem Tausch fortzufahren."

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -567,6 +567,7 @@
     "availableToDeposit": "Einzahlung möglich: ",
     "poolInfoDescription": "Jetzt haben Sie Ihren Pool ausgewählt und können Sie von dort abheben.",
     "dollarWorth": "Dollarwert: ",
+    "usd": "USD",
     "yourRate": "Ihr Tarif: ",
     "unclaimedPng": "Nicht beanspruchtes {{ pngSymbol }}: ",
     "shareOfPool": "Poolanteil: ",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -614,10 +614,10 @@
     "attemptingToConfirmApproval": "Attempting to confirm without approval or a signature. Please contact support."
   },
   "sarTitle":{
-    "addMore": "ADD MORE",
-    "unstake": "UNSTAKE A POSITION",
-    "compound": "COMPOUND REWARDS",
-    "claim": "CLAIM REWARDS",
+    "addMore": "Add",
+    "unstake": "Unstake",
+    "compound": "Compound",
+    "claim": "Claim",
     "interactingID": "Interacting with ID: {{ id }}"
   },
   "sarStake": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -390,7 +390,7 @@
     "managePool": "Manage this pool.",
     "noLiquidityYet": "You don't have liquidity in this pool yet.",
     "noPoolFound": "No pool found.",
-    "addLiquidity": "Add liquidity.",
+    "addLiquidity": "Add liquidity",
     "createPool": "Create pool.",
     "invalidPair": "Invalid pair.",
     "loading": "Loading"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -200,9 +200,8 @@
     "maximumSold": "Maximum Sold",
     "transactionRevertHelper": "Your transaction will revert if there is a large, unfavorable price movement before it is confirmed.",
     "priceUpdated": "Price Updated",
-    "outputEstimated": "Output is estimated. You will receive at least ",
-    "transactionRevert": " or the transaction will revert.",
-    "inputEstimated": "Input is estimated. You will sell at most ",
+    "outputEstimated": "Output is estimated. You will receive at least <strong>{{amount}} {{currencySymbol}}</strong> or the transaction will revert.",
+    "inputEstimated": "Input is estimated. You will sell at most <strong>{{amount}} {{currencySymbol}}</strong> or the transaction will revert.",
     "outputSentTo": "Output will be sent to ",
     "priceImpactMinPrompt": "This swap has a price impact of at least {{ priceImpact }}%. Please type the word \"confirm\" to continue with this swap.",
     "priceImpactHighPrompt": "This swap has a price impact of at least {{ priceImpact }}%. Please confirm that you would like to continue with this swap."

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -568,6 +568,7 @@
     "availableToDeposit": "Available to deposit: ",
     "poolInfoDescription": "Select the amount you wish to migrate",
     "dollarWorth": "Dollar Worth: ",
+    "usd": "USD",
     "yourRate": "Your rate: ",
     "unclaimedPng": "Unclaimed {{ pngSymbol }}: ",
     "shareOfPool": "Share of Pool: ",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -200,9 +200,8 @@
     "maximumSold": "Máximo vendido",
     "transactionRevertHelper": "Tu transacción se revertirá si hay un gran movimiento de precio desfavorable antes de ser confirmada..",
     "priceUpdated": "Precio actualiazdo",
-    "outputEstimated": "El resultado es estimado. Recibirá por lo menos ",
-    "transactionRevert": " o la transacción se revertirá.",
-    "inputEstimated": "El resultado es estimado. Venderá como mucho ",
+    "outputEstimated": "El resultado es estimado. Recibirá por lo menos <strong>{{amount}} {{currencySymbol}}</strong> o la transacción se revertirá.",
+    "inputEstimated": "El resultado es estimado. Venderá como mucho <strong>{{amount}} {{currencySymbol}}</strong> o la transacción se revertirá.",
     "outputSentTo": "La salida se mandará a ",
     "priceImpactMinPrompt": "Este intercambio tiene un impacto en el precio de por lo menos {{ priceImpact }}%. Por favor, escriba la palabra \"confirmar\" para continuar con este intercambio.",
     "priceImpactHighPrompt": "Este intercambio tiene un impacto en el precio de por lo menos {{ priceImpact }}%. Por favor, confirme que quiere continuar con este intercambio."

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -567,6 +567,7 @@
     "availableToDeposit": "Disponible para depositar: ",
     "poolInfoDescription": "Ahora que ha elegido su grupo, dejemos de apostar desde allí.",
     "dollarWorth": "Valor del dólar: ",
+    "usd": "USD",
     "yourRate": "Tu tarifa: ",
     "unclaimedPng": "{{ pngSymbol }} no reclamada: ",
     "shareOfPool": "Participación de la piscina: ",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -200,9 +200,8 @@
     "maximumSold": "Maximum vendu",
     "transactionRevertHelper": "Votre transaction sera annulée si un mouvement de prix important et défavorable se produit avant sa confirmation.",
     "priceUpdated": "Prix actualisé",
-    "outputEstimated": "La quantité produite est estimée. Vous recevrez au moins ",
-    "transactionRevert": " ou la transaction sera annulée.",
-    "inputEstimated": "La quantité produite est estimée. Vous vendrez au maximum ",
+    "outputEstimated": "La quantité produite est estimée. Vous recevrez au moins <strong>{{amount}} {{currencySymbol}}</strong> ou la transaction sera annulée.",
+    "inputEstimated": "La quantité produite est estimée. Vous vendrez au maximum <strong>{{amount}} {{currencySymbol}}</strong> ou la transaction sera annulée.",
     "outputSentTo": "La production sera envoyée à ",
     "priceImpactMinPrompt": "Cet échange a un impact sur les prix d'au moins {{ priceImpact }}%. Veuillez taper le mot \"confirmer\" pour poursuivre cet échange.",
     "priceImpactHighPrompt": "Cet échange a un impact sur les prix d'au moins {{ priceImpact }}%. Veuillez confirmer que vous souhaitez poursuivre cet échange."

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -567,6 +567,7 @@
     "availableToDeposit": "Disponible en dépôt: ",
     "poolInfoDescription": "Maintenant que vous avez choisi votre piscine, laissez-vous en dépareiller.",
     "dollarWorth": "Valeur en dollars : ",
+    "usd": "USD",
     "yourRate": "Votre tarif : ",
     "unclaimedPng": "{{ pngSymbol }} non réclamé : ",
     "shareOfPool": "Part du pool : ",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -566,6 +566,7 @@
     "availableToDeposit": "Disponível para depositar: ",
     "poolInfoDescription": "Agora que você escolheu sua piscina, vamos desamarrá-lo dela.",
     "dollarWorth": "Valor em dólar: ",
+    "usd": "USD",
     "yourRate": "Sua taxa: ",
     "unclaimedPng": "{{ pngSymbol }} não reivindicado: ",
     "shareOfPool": "Participação na Pool: ",

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -199,9 +199,8 @@
     "maximumSold": "Máximo vendido",
     "transactionRevertHelper": "Sua transação será revertida se houver um movimento de preço grande e desfavorável antes de ser confirmada.",
     "priceUpdated": "Preço atualizado",
-    "outputEstimated": "A saída é estimada. Você receberá pelo menos ",
-    "transactionRevert": " ou a transação será revertida.",
-    "inputEstimated": "A entrada é estimada. Você vai vender no máximo ",
+    "outputEstimated": "A saída é estimada. Você receberá pelo menos <strong>{{amount}} {{currencySymbol}}</strong> ou a transação será revertida.",
+    "inputEstimated": "A entrada é estimada. Você vai vender no máximo <strong>{{amount}} {{currencySymbol}}</strong> ou a transação será revertida.",
     "outputSentTo": "Saída será enviada para ",
     "priceImpactMinPrompt": "Este swap tem um impacto no preço de pelo menos {{ priceImpact }}%. Por favor, digite a palavra \"confirmar\" para continuar com este swap.",
     "priceImpactHighPrompt": "Este swap tem um impacto no preço de pelo menos {{ priceImpact }}%. . Por favor, confirme que você gostaria de continuar com este swap."

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -200,9 +200,8 @@
     "maximumSold": "Maksimum Satılacak",
     "transactionRevertHelper": "İşleminiz onaylanmadan önce büyük ve olumsuz bir fiyat hareketi olması halinde işleminiz gerçekleşmeyecektir.",
     "priceUpdated": "Fiyat Güncellendi",
-    "outputEstimated": "Çıktı(hasıla) yaklaşıktır. En az şu kadar alacaksınız: ",
-    "transactionRevert": " veya işleminiz gerçekleşmeyecektir.",
-    "inputEstimated": "Girdi yaklaşıktır. En fazla şu kadar satacaksınız: ",
+    "outputEstimated": "Çıktı(hasıla) yaklaşıktır. En az şu kadar alacaksınız: <strong>{{amount}} {{currencySymbol}}</strong> veya işleminiz gerçekleşmeyecektir.",
+    "inputEstimated": "Girdi yaklaşıktır. En fazla şu kadar satacaksınız: <strong>{{amount}} {{currencySymbol}}</strong> veya işleminiz gerçekleşmeyecektir.",
     "outputSentTo": "Çıktı(hasıla) şuraya gönderilecektir: ",
     "priceImpactMinPrompt": "Bu takas işleminin fiyata etkisi en az %{{ priceImpact }}'dır. Bu işleme devam etmek için lütfen \"onayla\" yazın.",
     "priceImpactHighPrompt": "Bu takas işleminin fiyata etkisi en az %{{ priceImpact }}'dır. Lütfen işleme devam etmek istediğinizi onaylayın."

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -566,6 +566,7 @@
     "availableToDeposit": "Yatırmaya müsait olan miktar: ",
     "poolInfoDescription": "Taşımak istediğiniz miktarı girin",
     "dollarWorth": "Dolar Karşılığı: ",
+    "usd": "USD",
     "yourRate": "Getiriniz: ",
     "unclaimedPng": "Talep Edilmemiş {{ pngSymbol }}: ",
     "shareOfPool": "Havuz Payı: ",

--- a/src/locales/vn.json
+++ b/src/locales/vn.json
@@ -200,9 +200,8 @@
     "maximumSold": "Bán tối đa",
     "transactionRevertHelper": "Giao dịch của bạn sẽ hoàn lại nếu có một biến động giá lớn, bất lợi trước khi nó được xác nhận .",
     "priceUpdated": "Giá đã được cập nhật",
-    "outputEstimated": "Đầu ra được ước tính.Bạn sẽ nhận lại tối thiểu",
-    "transactionRevert": " hoặc giao dịch sẽ hoàn lại.",
-    "inputEstimated": "Đầu vào được ước tính. Bạn sẽ bán được nhiều nhất",
+    "outputEstimated": "Đầu ra được ước tính.Bạn sẽ nhận lại tối thiểu <strong>{{amount}} {{currencySymbol}}</strong> hoặc giao dịch sẽ hoàn lại.",
+    "inputEstimated": "Đầu vào được ước tính. Bạn sẽ bán được nhiều nhất <strong>{{amount}} {{currencySymbol}}</strong> hoặc giao dịch sẽ hoàn lại.",
     "outputSentTo": "Đầu ra sẽ được gửi tới ",
     "priceImpactMinPrompt": "Sự hoán đổi này có tác động về giá ít nhất là  {{ priceImpact }}%. Vui lòng gõ từ \"confirm\" để tiếp tục thao tác hoán đổi này.",
     "priceImpactHighPrompt": "Sự hoán đổi này có tác động về giá ít nhất là  {{ priceImpact }}%. Vui lòng xác nhận rằng bạn muốn tiếp tục thao tác hoán đổi này."

--- a/src/locales/vn.json
+++ b/src/locales/vn.json
@@ -567,6 +567,7 @@
     "availableToDeposit": "Có sẵn để đặt cọc: ",
     "poolInfoDescription": "Bây giờ bạn đã chọn hồ bơi của mình, sau đó cho phép bạn rời khỏi đó.",
     "dollarWorth": "Giá trị đô la: ",
+    "usd": "USD",
     "yourRate": "Tỷ lệ của bạn: ",
     "unclaimedPng": "{{ pngSymbol }} vô thừa nhận: ",
     "shareOfPool": "Chia sẻ của Pool: ",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -200,9 +200,8 @@
     "maximumSold": "最大销售量",
     "transactionRevertHelper": "如果在确认前出现较大的不利价格变动，您的交易将取消。",
     "priceUpdated": "价格更新",
-    "outputEstimated": "估计输出。你至少会收到 ",
-    "transactionRevert": " 否则交易将取消。",
-    "inputEstimated": "输入是估计的。你最多会卖掉 ",
+    "outputEstimated": "估计输出。你至少会收到 <strong>{{amount}} {{currencySymbol}}</strong>  否则交易将取消。",
+    "inputEstimated": "输入是估计的。你最多会卖掉 <strong>{{amount}} {{currencySymbol}}</strong>  否则交易将取消。",
     "outputSentTo": "输出将发送到 ",
     "priceImpactMinPrompt": "此兌換对价格的影响至少为 {{ priceImpact }}%. 请输入\"确\" 继续这个兌換。",
     "priceImpactHighPrompt": "此兌換对价格的影响至少为 {{ priceImpact }}%. 请确认您想继续进行此兌换。"

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -566,6 +566,7 @@
     "availableToDeposit": "可存入 ",
     "poolInfoDescription": "现在您已经选择了您的池，然后让您从那里取消赌注",
     "dollarWorth": "美元价值 ",
+    "usd": "USD",
     "yourRate": "您的费率 ",
     "unclaimedPng": "无人认领的{{ pngSymbol }}: ",
     "shareOfPool": "池份额 ",

--- a/src/state/pswap/hooks.ts
+++ b/src/state/pswap/hooks.ts
@@ -242,7 +242,7 @@ export function useDerivedSwapInfo(): {
   ];
 
   if (balanceIn && amountIn && balanceIn.lessThan(amountIn)) {
-    inputError = 'Insufficient' + amountIn.currency.symbol + ' balance';
+    inputError = 'Insufficient ' + amountIn.currency.symbol + ' balance';
   }
 
   const isLoading = isExactIn ? isLoadingIn : isLoadingOut;


### PR DESCRIPTION
This PR includes;

on mobile amount keyboard should be numeric -> https://app.clickup.com/t/3bufced
The title "Add liquidity" has an extra full stop in the end -> https://app.clickup.com/t/3ch99bu
The "Dollar Worth" on the "Add liquidity" menu should be "USD" -> https://app.clickup.com/t/3chhqcz
There is a spacing issue in the message on the "Trade" menu -> https://app.clickup.com/t/3chhnac
There is no space between the text "Insufficient" and "Token name" -> https://app.clickup.com/t/3cbjeye
There is an alignment issue with the Balance in Add liquidity -> https://app.clickup.com/t/3cbjv7c
Mobile Stake V2 title update -> https://app.clickup.com/t/3bufdg0
The "Select a token" form is not properly aligned and is broken. -> https://app.clickup.com/t/3cq0hfa