### PR TITLE
fix: import abi

### DIFF
--- a/src/constants/abis/pangolinPair.ts
+++ b/src/constants/abis/pangolinPair.ts
@@ -1,6 +1,6 @@
 import { Interface } from '@ethersproject/abi';
-import { abi as IPangolinPairABI } from '@pangolindex/exchange-contracts/artifacts/contracts/pangolin-core/interfaces/IPangolinPair.sol/IPangolinPair.json';
+import IPangolinPair from '@pangolindex/exchange-contracts/artifacts/contracts/pangolin-core/interfaces/IPangolinPair.sol/IPangolinPair.json';
 
-const PANGOLIN_PAIR_INTERFACE = new Interface(IPangolinPairABI);
+const PANGOLIN_PAIR_INTERFACE = new Interface(IPangolinPair.abi);
 
 export { PANGOLIN_PAIR_INTERFACE };


### PR DESCRIPTION
make default import instead of named import when there is no named export in importing file

![2022-09-12 13 05 21](https://user-images.githubusercontent.com/6604146/189598026-2aca1edf-b1e5-4d0c-8b83-1b9d8365b0d4.jpg)
