### PR TITLE
fix: bridge-swap cosmos bugs

### DIFF
--- a/src/hooks/bridge/Chains.ts
+++ b/src/hooks/bridge/Chains.ts
@@ -48,7 +48,7 @@ export function useSquidChains() {
             cosmosPrefix: chain?.bech32Config?.bech32PrefixAccAddr,
           },
         }),
-        name: chain?.chainName,
+        name: chain?.chainName.charAt(0).toLocaleUpperCase() + chain?.chainName.slice(1),
         chain_id: chain?.chainId,
         mainnet: true,
         evm: chain?.chainType === 'evm',

--- a/src/state/pbridge/hooks.ts
+++ b/src/state/pbridge/hooks.ts
@@ -391,7 +391,7 @@ export function useBridgeSwapActionHandlers(): {
         };
       });
 
-      const params: GetRoute = {
+      const params: Omit<GetRoute, 'toAddress'> & Partial<Pick<GetRoute, 'toAddress'>> = {
         fromChain: fromChain?.chain_id || 1,
         fromToken:
           fromCurrency?.address
@@ -403,7 +403,7 @@ export function useBridgeSwapActionHandlers(): {
           toCurrency?.address
             ?.toString()
             ?.replace('0x0000000000000000000000000000000000000000', '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE') || '',
-        ...((recipient || fromAddress) && { toAddress: recipient || fromAddress }),
+        ...((recipient || fromAddress) && { toAddress: recipient || fromAddress || '' }),
         slippage: parseFloat(slipLimit),
         enableForecall: true,
         quoteOnly: recipient || fromAddress ? false : true,

--- a/src/state/pbridge/hooks.ts
+++ b/src/state/pbridge/hooks.ts
@@ -403,9 +403,10 @@ export function useBridgeSwapActionHandlers(): {
           toCurrency?.address
             ?.toString()
             ?.replace('0x0000000000000000000000000000000000000000', '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE') || '',
-        toAddress: recipient || fromAddress || '0x0000000000000000000000000000000000000000',
+        ...((recipient || fromAddress) && { toAddress: recipient || fromAddress }),
         slippage: parseFloat(slipLimit),
         enableForecall: true,
+        quoteOnly: recipient || fromAddress ? false : true,
       };
 
       let squidRouteRes: RouteResponse | null;


### PR DESCRIPTION
## Summary

- Get routes only if required inputs are filled.
- Cosmos Chain Names

0xSquid Side;

This feature is also related to the 0xSquid team's developments.

1- `quoteOnly` field should work with Cosmos networks. (And then need another development on our side; we don't need to wait for the Cosmos Wallet address to get the route.)
2- Their SDK-type development. One of the fields is required even if it shouldn't. They need to fix this.