### PR TITLE
fix: hedera ui issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
   "engines": {
-    "node": ">=14.21.1 <=16.18.1"
+    "node": ">=14.x.x <=16.x.x"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/components/SwapWidget/MarketOrder/index.tsx
+++ b/src/components/SwapWidget/MarketOrder/index.tsx
@@ -392,7 +392,7 @@ const MarketOrder: React.FC<Props> = ({
     if (showWrap) {
       return (
         <Button variant="primary" isDisabled={Boolean(wrapInputError)} onClick={onWrap}>
-          {wrapInputError ?? (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'unwrap' : null)}
+          {wrapInputError ?? (wrapType === WrapType.WRAP ? 'Wrap' : wrapType === WrapType.UNWRAP ? 'Unwrap' : null)}
         </Button>
       );
     }

--- a/src/components/SwapWidget/SelectTokenDrawer/index.tsx
+++ b/src/components/SwapWidget/SelectTokenDrawer/index.tsx
@@ -170,7 +170,7 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
               columnWidth={(width - 10) / 4}
               rowHeight={120}
               columnCount={4}
-              rowCount={currencies.length / 4}
+              rowCount={Math.ceil(currencies.length / 4)}
               width={width}
               itemData={currencies}
               itemKey={({ columnIndex, rowIndex, data }) => currencyKey(columnIndex, rowIndex, data, chainId)}

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -468,11 +468,10 @@ export function useHederaTokenAssociated(
                 setLoading(true);
                 const txReceipt = await hederaFn.tokenAssociate(address, account);
                 if (txReceipt) {
-                  setLoading(false);
                   refetch();
-
                   addTransaction(txReceipt, { summary: `${symbol} successfully  associated` });
                 }
+                setLoading(false);
               } catch (error) {
                 setLoading(false);
                 console.error('Could not deposit', error);

--- a/src/hooks/useWrapCallback.ts
+++ b/src/hooks/useWrapCallback.ts
@@ -187,7 +187,7 @@ export function useWrapHbarCallback(
   typedValue: string | undefined,
 ): { wrapType: WrapType; execute?: () => Promise<void>; inputError?: string } {
   const { account } = usePangolinWeb3();
-
+  const { t } = useTranslation();
   const chainId = useChainId();
 
   const balance = useCurrencyBalance(chainId, account ?? undefined, inputCurrency);
@@ -203,9 +203,15 @@ export function useWrapHbarCallback(
   return useMemo(() => {
     if (!chainId || !inputCurrency || !outputCurrency || !account) return NOT_APPLICABLE;
 
+    let inputError = !typedValue ? t('swapHooks.enterAmount') : undefined;
+
     const sufficientBalance = inputAmount && balance && !balance.lessThan(inputAmount);
 
     if (inputCurrency === CAVAX[chainId] && currencyEquals(WAVAX[chainId], outputCurrency)) {
+      inputError =
+        inputError ??
+        (sufficientBalance ? undefined : t('swapHooks.insufficientBalance', { symbol: CAVAX[chainId].symbol }));
+
       return {
         wrapType: WrapType.WRAP,
         execute:
@@ -222,9 +228,12 @@ export function useWrapHbarCallback(
                 }
               }
             : undefined,
-        inputError: sufficientBalance ? undefined : 'Insufficient HBAR balance',
+        inputError: inputError,
       };
     } else if (currencyEquals(WAVAX[chainId], inputCurrency) && outputCurrency === CAVAX[chainId]) {
+      inputError =
+        inputError ??
+        (sufficientBalance ? undefined : t('swapHooks.insufficientBalance', { symbol: WAVAX[chainId].symbol }));
       return {
         wrapType: WrapType.UNWRAP,
         execute:
@@ -243,7 +252,7 @@ export function useWrapHbarCallback(
                 }
               }
             : undefined,
-        inputError: sufficientBalance ? undefined : 'Insufficient WHBAR balance',
+        inputError: inputError,
       };
     } else {
       return NOT_APPLICABLE;


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Before submitting a pull request, please make sure the following is done:

  1. Run `yarn` in the repository root.
  2. Run `yarn lint` make sure to fix if any linting issues
  3. Run `yarn tsc` make sure to fix any typescript issues
  4. if you have added new components make sure to add storybook for those components
-->

## Summary

<!--
 Explain summary of the change
-->
1. The "Associate" button turns to "Associating" button and gets disabled if the user rejects the transaction
2. For the very first time the "WHBAR" token appears on the field, but there is no "WHBAR" token in the token list
3.  The fields don't set to 0.00 after successfully wrapped
4. The button shows "Insufficient HBAR balance" instead of "Enter an amount"
5. The "unwrap" button on the "Trade" card has a UI issue
## Tasks
https://app.clickup.com/t/86699t8er


## Screenshots/Videos

<!--
  Please attach screenshots / videos if the pull request changes the user interface
-->

![Screenshot 2023-01-13 at 15-11-27 Pangolin Components Example](https://user-images.githubusercontent.com/6604146/212321972-769f628e-a076-46d3-8660-8483bf5ed278.png)
![t2](https://user-images.githubusercontent.com/6604146/212321979-2175575d-eaf3-4c91-84aa-a9a02f13ae73.png)
![t3](https://user-images.githubusercontent.com/6604146/212322290-0ab3101a-13f0-41bf-bc2b-9382a651cebb.png)
