### PR TITLE
change output currency for Hedera Mainnet

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -259,7 +259,7 @@ export const SWAP_DEFAULT_CURRENCY = {
   },
   [ChainId.HEDERA_MAINNET]: {
     inputCurrency: 'HBAR',
-    outputCurrency: WAVAX[ChainId.HEDERA_MAINNET].address,
+    outputCurrency: '',
   },
   [ChainId.NEAR_MAINNET]: {
     inputCurrency: WAVAX[ChainId.NEAR_MAINNET].address,


### PR DESCRIPTION
WHBAR shouldn't be the output currency. I think we should keep it blank until we get more liquidity to HBAR-USDC(hts) pool.

<!--
  Thanks for submitting a pull request!
  Before submitting a pull request, please make sure the following is done:

  1. Run `yarn` in the repository root.
  2. Run `yarn lint` make sure to fix if any linting issues
  3. Run `yarn tsc` make sure to fix any typescript issues
  4. if you have added new components make sure to add storybook for those components
-->

## Summary

<!--
 Explain summary of the change
-->

## Tasks

<!--
 Please attach task links here
-->

## Screenshots/Videos

<!--
  Please attach screenshots / videos if the pull request changes the user interface
-->

