### PR TITLE
fix: remove hashpack data from local storage to fix the secret key error

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -169,9 +169,8 @@ const WalletModal: React.FC<WalletModalProps> = ({
         .then(() => {
           if (isCbWallet) {
             addAvalancheNetwork();
-          } else {
-            onWalletConnect(getConnectorKey(activationConnector));
           }
+          onWalletConnect(getConnectorKey(activationConnector));
           mixpanel.track(MixPanelEvents.WALLET_CONNECT, {
             wallet_name: option?.name ?? name?.toLowerCase(),
           });


### PR DESCRIPTION
## Summary

- Removed pangolin hashpack data from local storage to fix the "secret key" error, this is probably caused by the data saved in the local storage being out of date
- now `isAuthorized` is based on `pairingData`, `encryptionKey` & `pairingData.length`. Ref: https://github.com/Hashpack/hashconnect/blob/main/lib/src/hashconnect.ts#L234-L252

![image (1)](https://user-images.githubusercontent.com/6604146/217436824-476a40b6-8756-4b70-a550-9b9d97d3124d.png)

