### PR TITLE
fix: balance blink issue with keeping previously cached data until new is received

### DIFF
--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -264,11 +264,17 @@ export function useGetAllHederaAssociatedTokens(dependancies = [] as any[]) {
 
   const { account } = usePangolinWeb3();
 
-  const response = useQuery(['check-hedera-token-associated', account, ...dependancies], async () => {
-    if (!account || !hederaFn.isHederaChain(chainId)) return;
-    const tokens = await hederaFn.getAccountAssociatedTokens(account);
-    return tokens;
-  });
+  const response = useQuery(
+    ['check-hedera-token-associated', account, ...dependancies],
+    async () => {
+      if (!account || !hederaFn.isHederaChain(chainId)) return;
+      const tokens = await hederaFn.getAccountAssociatedTokens(account);
+      return tokens;
+    },
+    {
+      keepPreviousData: true,
+    },
+  );
 
   return response;
 }


### PR DESCRIPTION
## Summary

-  Hedera Balance blink issue in Add Liquidity Widget due to we are always trying to fetch latest balance on new block number and it will return 0/undefined while its fetching new data. so to make it not blink balance to 0 while its fetching, we are going to keep returning previously cached data
