### PR TITLE
fix: pools not showing in your pools

### DIFF
--- a/src/utils/hedera.ts
+++ b/src/utils/hedera.ts
@@ -41,6 +41,7 @@ export interface HederaTokenMetadata {
   symbol: string;
   decimals: number;
   icon: string;
+  type: string;
 }
 
 export interface HederaAssociateTokensData {
@@ -420,6 +421,7 @@ class Hedera {
         symbol: tokenInfo?.symbol,
         decimals: Number(tokenInfo?.decimals),
         icon: '',
+        type: tokenInfo?.type,
       };
       return token;
     } catch (error) {


### PR DESCRIPTION
## Summary

- When you have a nft associated in wallet it cause a multicall revert because it is querying for the decimals() function but nfts doesn't have that function, to fix this we need to query the token's metadata and check if this is fungible

## Screenshots/Videos
![image](https://user-images.githubusercontent.com/37405304/219087338-6025268f-665c-4b0b-b238-e23b5f663c3d.png)
