### PR TITLE
fix: hedera bugs and reduce more onchain calls

### DIFF
--- a/src/apollo/pangochef.ts
+++ b/src/apollo/pangochef.ts
@@ -22,7 +22,8 @@ export interface PangoChefFarm {
   weight: string;
   tokenOrRecipientAddress: string;
   rewarder: PangochefFarmRewarder;
-  pair: PangochefPair;
+  // pair can be null in relayer pool case
+  pair: PangochefPair | null;
   farmingPositions: {
     stakedTokenBalance: string;
   }[];
@@ -146,6 +147,10 @@ export const useSubgraphFarms = () => {
       const data = await gqlClient.request(GET_PANGOCHEF, {
         userAddress: account ? account.toLowerCase() : '',
       });
+      console.log(
+        'pairs',
+        data?.pangoChefs?.[0]?.farms?.map((farm) => farm.pair),
+      );
       return data?.pangoChefs;
     },
     {

--- a/src/apollo/pangochef.ts
+++ b/src/apollo/pangochef.ts
@@ -147,10 +147,6 @@ export const useSubgraphFarms = () => {
       const data = await gqlClient.request(GET_PANGOCHEF, {
         userAddress: account ? account.toLowerCase() : '',
       });
-      console.log(
-        'pairs',
-        data?.pangoChefs?.[0]?.farms?.map((farm) => farm.pair),
-      );
       return data?.pangoChefs;
     },
     {

--- a/src/components/Pools/DetailModal/Header/index.tsx
+++ b/src/components/Pools/DetailModal/Header/index.tsx
@@ -103,7 +103,7 @@ const Header: React.FC<Props> = ({ stakingInfo, onClose }) => {
   };
 
   const { totalApr, stakingApr, swapFeeApr, userApr } = getAPRs();
-  console.log({ totalApr, stakingApr, extraFarmAPR, swapFeeApr, userApr, _userApr, extraUserAPR });
+
   return (
     <HeaderRoot>
       <HeaderWrapper>

--- a/src/components/Pools/DetailModal/Header/index.tsx
+++ b/src/components/Pools/DetailModal/Header/index.tsx
@@ -103,7 +103,7 @@ const Header: React.FC<Props> = ({ stakingInfo, onClose }) => {
   };
 
   const { totalApr, stakingApr, swapFeeApr, userApr } = getAPRs();
-
+  console.log({ totalApr, stakingApr, extraFarmAPR, swapFeeApr, userApr, _userApr, extraUserAPR });
   return (
     <HeaderRoot>
       <HeaderWrapper>

--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -191,7 +191,7 @@ export function useHederaPairs(currencies: [Currency | undefined, Currency | und
     () =>
       tokens.map(([tokenA, tokenB]) => {
         return tokenA && tokenB && !tokenA.equals(tokenB)
-          ? Pair.getAddress(tokenA, tokenB, chainId ? chainId : ChainId.AVALANCHE)?.toLowerCase()
+          ? Pair.getAddress(tokenA, tokenB, chainId ? chainId : ChainId.AVALANCHE)
           : undefined;
       }),
     [tokens, chainId],

--- a/src/data/TotalSupply.ts
+++ b/src/data/TotalSupply.ts
@@ -3,7 +3,7 @@ import { ChainId, Pair, Token, TokenAmount } from '@pangolindex/sdk';
 import { useEffect, useMemo, useState } from 'react';
 import { useSubgraphPairs } from 'src/apollo/pairs';
 import { useChainId } from 'src/hooks';
-import { useHederaPGLToken, useHederaTokensMetaData } from 'src/state/pwallet/hooks';
+import { useHederaTokensMetaData } from 'src/state/pwallet/hooks';
 import { nearFn } from 'src/utils/near';
 import { PNG } from '../constants/tokens';
 import { useTokenContract } from '../hooks/useContract';
@@ -104,32 +104,14 @@ export function useNearPairTotalSupply(pair?: Pair): TokenAmount | undefined {
 export function usePairTotalSupplyViaSubgraph(pair?: Pair): TokenAmount | undefined {
   const token = pair?.liquidityToken;
   // get pair from subgraph
-  const { data, isLoading } = useSubgraphPairs([token?.address?.toLowerCase()]);
+  const { data, isLoading } = useSubgraphPairs([token?.address]);
 
   return useMemo(() => {
     if (!token || isLoading || !data || data.length === 0) return undefined;
 
     const pairInfo = data[0];
-    if (pairInfo.id.toLowerCase() !== token.address.toLowerCase()) return undefined;
+    if (pairInfo.id !== token.address) return undefined;
 
     return new TokenAmount(token, pairInfo.totalSupply);
   }, [token, data, isLoading]);
-}
-
-/**
- * this hook is used to fetch total supply of given Hedera pair
- * @param pair pair object
- * @returns total supply in form of TokenAmount or undefined
- */
-export function useHederaPairTotalSupply(pair?: Pair): TokenAmount | undefined {
-  const [pglToken, liqToken] = useHederaPGLToken(pair?.token0, pair?.token1);
-
-  const tokensMetadata = useHederaTokensMetaData([pglToken?.address]);
-
-  const totalSupply = pglToken?.address ? tokensMetadata[pglToken?.address]?.totalSupply : '0';
-
-  // here we create TokenAmount with liqToken so that we can use sdk methods like `pair.getLiquidityMinted` etc
-  // we need to do this because in sdk its checking token equality
-  // @link https://github.com/pangolindex/sdk/blob/dev/src/entities/pools/pair.ts#L146
-  return pglToken && liqToken && pair && totalSupply ? new TokenAmount(liqToken, totalSupply.toString()) : undefined;
 }

--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -8,6 +8,7 @@ import {
   useHederaTotalSupply,
   useNearPairTotalSupply,
   useNearTotalSupply,
+  usePairTotalSupplyViaSubgraph,
   useTotalSupply,
 } from './TotalSupply';
 
@@ -128,6 +129,7 @@ export type UsePairTotalSupplyHookType = {
     | typeof useEvmPairTotalSupply
     | typeof useNearPairTotalSupply
     | typeof useHederaPairTotalSupply
+    | typeof usePairTotalSupplyViaSubgraph
     | typeof useDummyHook;
 };
 
@@ -143,8 +145,8 @@ export const usePairTotalSupplyHook: UsePairTotalSupplyHookType = {
   [ChainId.COSTON]: useEvmPairTotalSupply,
   [ChainId.SONGBIRD]: useEvmPairTotalSupply,
   [ChainId.FLARE_MAINNET]: useEvmPairTotalSupply,
-  [ChainId.HEDERA_TESTNET]: useHederaPairTotalSupply,
-  [ChainId.HEDERA_MAINNET]: useHederaPairTotalSupply,
+  [ChainId.HEDERA_TESTNET]: usePairTotalSupplyViaSubgraph,
+  [ChainId.HEDERA_MAINNET]: usePairTotalSupplyViaSubgraph,
   [ChainId.NEAR_MAINNET]: useNearPairTotalSupply,
   [ChainId.NEAR_TESTNET]: useNearPairTotalSupply,
   [ChainId.COSTON2]: useEvmPairTotalSupply,

--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -4,7 +4,6 @@ import { useTokenAllowance } from './Allowances';
 import { useHederaPairs, useNearPairs, usePairs } from './Reserves';
 import {
   useEvmPairTotalSupply,
-  useHederaPairTotalSupply,
   useHederaTotalSupply,
   useNearPairTotalSupply,
   useNearTotalSupply,
@@ -128,7 +127,6 @@ export type UsePairTotalSupplyHookType = {
   [chainId in ChainId]:
     | typeof useEvmPairTotalSupply
     | typeof useNearPairTotalSupply
-    | typeof useHederaPairTotalSupply
     | typeof usePairTotalSupplyViaSubgraph
     | typeof useDummyHook;
 };

--- a/src/state/ppangoChef/hooks.ts
+++ b/src/state/ppangoChef/hooks.ts
@@ -37,7 +37,7 @@ import { useHederaPGLTokenAddresses, useHederaPairContractEVMAddresses } from 's
 import { calculateGasMargin, decimalToFraction, waitForTransaction } from 'src/utils';
 import { hederaFn } from 'src/utils/hedera';
 import { useMultipleContractSingleData, useSingleCallResult, useSingleContractMultipleData } from '../pmulticall/hooks';
-import { PangoChefInfo, Pool, PoolType, RewardSummations, UserInfo, ValueVariables } from './types';
+import { PangoChefInfo, Pool, PoolType, UserInfo, ValueVariables } from './types';
 import { calculateCompoundSlippage } from './utils';
 
 export function usePangoChefInfos() {
@@ -72,9 +72,8 @@ export function usePangoChefInfos() {
       const rewarder = result.rewarder;
       const rewardPair = result.rewardPair;
       const valueVariables = result.valueVariables as ValueVariables;
-      const rewardSummations = result.rewardSummationsStored as RewardSummations;
 
-      if (!tokenOrRecipient || !poolType || !rewarder || !rewardPair || !valueVariables || !rewardSummations) {
+      if (!tokenOrRecipient || !poolType || !rewarder || !rewardPair || !valueVariables) {
         continue;
       }
 
@@ -92,7 +91,6 @@ export function usePangoChefInfos() {
           balance: valueVariables?.balance,
           sumOfEntryTimes: valueVariables?.sumOfEntryTimes,
         } as ValueVariables,
-        rewardSummations: rewardSummations,
       } as Pool);
 
       _poolsIds.push([i.toString()]);
@@ -198,10 +196,9 @@ export function usePangoChefInfos() {
       }
 
       const valueVariables = result.valueVariables as ValueVariables;
-      const rewardSummations = result.rewardSummationsPaid as RewardSummations;
       const previousValues = result.previousValues;
 
-      if (!valueVariables || !rewardSummations || !previousValues) {
+      if (!valueVariables || !previousValues) {
         return {
           valueVariables: {
             balance: BigNumber.from(0),
@@ -225,7 +222,6 @@ export function usePangoChefInfos() {
           balance: valueVariables?.balance,
           sumOfEntryTimes: valueVariables?.sumOfEntryTimes,
         } as ValueVariables,
-        rewardSummations: rewardSummations,
         previousValues: previousValues,
         lockCount: lockCount,
       } as UserInfo;
@@ -475,9 +471,8 @@ export function useHederaPangoChefInfos() {
       const rewarder = result.rewarder;
       const rewardPair = result.rewardPair;
       const valueVariables = result.valueVariables as ValueVariables;
-      const rewardSummations = result.rewardSummationsStored as RewardSummations;
 
-      if (!tokenOrRecipient || !poolType || !rewarder || !rewardPair || !valueVariables || !rewardSummations) {
+      if (!tokenOrRecipient || !poolType || !rewarder || !rewardPair || !valueVariables) {
         continue;
       }
 
@@ -495,7 +490,6 @@ export function useHederaPangoChefInfos() {
           balance: valueVariables?.balance,
           sumOfEntryTimes: valueVariables?.sumOfEntryTimes,
         } as ValueVariables,
-        rewardSummations: rewardSummations,
       } as Pool);
 
       _poolsIds.push([i.toString()]);
@@ -611,10 +605,9 @@ export function useHederaPangoChefInfos() {
       }
 
       const valueVariables = result.valueVariables as ValueVariables;
-      const rewardSummations = result.rewardSummationsPaid as RewardSummations;
       const previousValues = result.previousValues;
 
-      if (!valueVariables || !rewardSummations || !previousValues) {
+      if (!valueVariables || !previousValues) {
         return {
           valueVariables: {
             balance: BigNumber.from(0),
@@ -629,7 +622,6 @@ export function useHederaPangoChefInfos() {
           balance: valueVariables?.balance,
           sumOfEntryTimes: valueVariables?.sumOfEntryTimes,
         } as ValueVariables,
-        rewardSummations: rewardSummations,
         previousValues: previousValues,
         lockCount: result.lockCount,
       } as UserInfo;
@@ -903,9 +895,8 @@ export function useGetPangoChefInfosViaSubgraph() {
       const rewarder = result.rewarder;
       const rewardPair = result.rewardPair;
       const valueVariables = result.valueVariables as ValueVariables;
-      const rewardSummations = result.rewardSummationsStored as RewardSummations;
 
-      if (!tokenOrRecipient || !poolType || !rewarder || !rewardPair || !valueVariables || !rewardSummations) {
+      if (!tokenOrRecipient || !poolType || !rewarder || !rewardPair || !valueVariables) {
         continue;
       }
 
@@ -922,7 +913,6 @@ export function useGetPangoChefInfosViaSubgraph() {
           balance: valueVariables?.balance,
           sumOfEntryTimes: valueVariables?.sumOfEntryTimes,
         } as ValueVariables,
-        rewardSummations: rewardSummations,
       };
     }
 
@@ -968,10 +958,9 @@ export function useGetPangoChefInfosViaSubgraph() {
       }
 
       const valueVariables = result.valueVariables as ValueVariables;
-      const rewardSummations = result.rewardSummationsPaid as RewardSummations;
       const previousValues = result.previousValues;
 
-      if (!valueVariables || !rewardSummations || !previousValues) {
+      if (!valueVariables || !previousValues) {
         return {
           valueVariables: {
             balance: BigNumber.from(0),
@@ -986,7 +975,6 @@ export function useGetPangoChefInfosViaSubgraph() {
           balance: valueVariables?.balance,
           sumOfEntryTimes: valueVariables?.sumOfEntryTimes,
         } as ValueVariables,
-        rewardSummations: rewardSummations,
         previousValues: previousValues,
         lockCount: result.lockCount,
       } as UserInfo;

--- a/src/state/ppangoChef/hooks.ts
+++ b/src/state/ppangoChef/hooks.ts
@@ -934,12 +934,8 @@ export function useGetPangoChefInfosViaSubgraph() {
     return allPoolsIds.map((pid) => [pid[0], account]);
   }, [allPoolsIds, account]); // [[pid, account], ...] [[0, account], [1, account], [2, account] ...]
 
-  // for hedera by cutting costs let's eliminate this call
-  // and just use the balance of the subgraph and sumOfEntryTimes as 0
-  // since we are not going to use that because hedera has the correct values
-  // for reward rate and with that is not to use sumOfEntryTimes
   const userInfosState = useSingleContractMultipleData(
-    hederaFn.isHederaChain(chainId) ? null : pangoChefContract,
+    pangoChefContract,
     'getUser',
     !shouldCreateStorage && userInfoInput ? userInfoInput : [],
   );

--- a/src/state/ppangoChef/hooks.ts
+++ b/src/state/ppangoChef/hooks.ts
@@ -934,10 +934,23 @@ export function useGetPangoChefInfosViaSubgraph() {
     return allPoolsIds.map((pid) => [pid[0], account]);
   }, [allPoolsIds, account]); // [[pid, account], ...] [[0, account], [1, account], [2, account] ...]
 
+  // let's just call getUser only when the user has a staked value so
+  // that we can access the lockCount of the user's pool
+  const isUserStaked = useMemo(
+    () =>
+      allFarms.some(
+        (farm) => farm.farmingPositions.length > 0 && Number(farm.farmingPositions[0].stakedTokenBalance) > 0,
+      ),
+    [allFarms],
+  );
+
   const userInfosState = useSingleContractMultipleData(
     pangoChefContract,
     'getUser',
-    !shouldCreateStorage && userInfoInput ? userInfoInput : [],
+    !shouldCreateStorage && isUserStaked ? userInfoInput : [],
+    {
+      blocksPerFetch: 20,
+    },
   );
 
   // format the data to UserInfo type

--- a/src/state/ppangoChef/hooks.ts
+++ b/src/state/ppangoChef/hooks.ts
@@ -978,6 +978,11 @@ export function useGetPangoChefInfosViaSubgraph() {
         return getAddress(tokenObj.id);
       });
 
+      const rewardTokens = rewards.map((rewardToken: PangochefFarmReward) => {
+        const tokenObj = rewardToken.token;
+        return new Token(chainId, getAddress(tokenObj.id), Number(tokenObj.decimals), tokenObj.symbol, tokenObj.name);
+      });
+
       const rewardMultipliers: JSBI[] = rewards.map((rewardToken: PangochefFarmReward) => {
         return JSBI.BigInt(rewardToken?.multiplier.toString());
       });
@@ -1142,6 +1147,7 @@ export function useGetPangoChefInfosViaSubgraph() {
         stakedAmount: userTotalStakedAmount,
         periodFinish: undefined,
         multiplier,
+        rewardTokens,
         rewardTokensAddress,
         rewardTokensMultiplier: rewardMultipliers,
         totalStakedInWavax: totalStakedInWavax,

--- a/src/state/ppangoChef/types.ts
+++ b/src/state/ppangoChef/types.ts
@@ -13,14 +13,8 @@ export interface ValueVariables {
   sumOfEntryTimes: BigNumber;
 }
 
-export interface RewardSummations {
-  idealPosition: BigNumber;
-  rewardPerValue: BigNumber;
-}
-
 export interface UserInfo {
   valueVariables: ValueVariables;
-  rewardSummations: RewardSummations;
   previousValues: BigNumber;
   lockCount: number | undefined;
 }
@@ -31,7 +25,6 @@ export interface Pool {
   rewarder: string;
   rewardPair: string;
   valueVariables: ValueVariables;
-  rewardSummations: RewardSummations;
 }
 
 export interface PangoChefInfo extends MinichefStakingInfo {


### PR DESCRIPTION
## Summary

- Added Hook to use pair total supply from subgraph
- Fixed the getUser, we need to query thos data in hedera to get lockCount of farm to show locked farm warning
- Fixed the getUser call to only call if the user has staked amount in farms
- Remove rewardsSummations because is unused value
- Remove `pools()` call and replaced values from this call with values provided by subgraph
- Added reward tokens in return of useGetPangoChefInfosViaSubgraph

