### PR TITLE
fix: export useful hooks and utility functions for interface

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -20,7 +20,7 @@ import { getContract } from 'src/utils';
 import { hederaFn } from 'src/utils/hedera';
 
 // returns null on errors
-function useContract(address: string | undefined, ABI: any, withSignerIfPossible = true): Contract | null {
+export function useContract(address: string | undefined, ABI: any, withSignerIfPossible = true): Contract | null {
   const { account } = usePangolinWeb3();
   const { library } = useLibrary();
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,15 +6,30 @@ import { Trans, useTranslation } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import SelectTokenDrawer from 'src/components/SwapWidget/SelectTokenDrawer';
+import { useTokenAllowance } from 'src/data/Allowances';
 import { usePair } from 'src/data/Reserves';
 import { useTotalSupply } from 'src/data/TotalSupply';
 import { useTotalSupplyHook } from 'src/data/multiChainsHooks';
 import { PangolinWeb3Provider, useLibrary } from 'src/hooks';
 import { useAllTokens } from 'src/hooks/Tokens';
 import { useUSDCPriceHook } from 'src/hooks/multiChainsHooks';
+import {
+  useContract,
+  useMulticallContract,
+  usePairContract,
+  usePngContract,
+  useStakingContract,
+  useTokenContract,
+} from 'src/hooks/useContract';
+import useDebounce from 'src/hooks/useDebounce';
+import useENS from 'src/hooks/useENS';
+import useInterval from 'src/hooks/useInterval';
+import useIsWindowVisible from 'src/hooks/useIsWindowVisible';
+import { useOnClickOutside } from 'src/hooks/useOnClickOutside';
 import useParsedQueryString from 'src/hooks/useParsedQueryString';
 import { useUSDCPrice } from 'src/hooks/useUSDCPrice';
 import ApplicationUpdater from 'src/state/papplication/updater';
+import { useCoinGeckoTokenData } from 'src/state/pcoingecko/hooks';
 import ListsUpdater from 'src/state/plists/updater';
 import MulticallUpdater from 'src/state/pmulticall/updater';
 import { usePangoChefInfosHook } from 'src/state/ppangoChef/multiChainsHooks';
@@ -52,8 +67,13 @@ import TransactionUpdater from 'src/state/ptransactions/updater';
 import { useGetUserLP, useTokenBalance } from 'src/state/pwallet/hooks';
 import { useAccountBalanceHook, useTokenBalanceHook } from 'src/state/pwallet/multiChainsHooks';
 import { existSarContract, getEtherscanLink, isEvmChain, shortenAddress, shortenAddressMapping } from 'src/utils';
+import chunkArray from 'src/utils/chunkArray';
+import listVersionLabel from 'src/utils/listVersionLabel';
 import { nearFn } from 'src/utils/near';
-import { wrappedCurrency } from 'src/utils/wrappedCurrency';
+import { parseENSAddress } from 'src/utils/parseENSAddress';
+import { splitQuery } from 'src/utils/query';
+import uriToHttp from 'src/utils/uriToHttp';
+import { unwrappedToken, wrappedCurrency, wrappedCurrencyAmount } from 'src/utils/wrappedCurrency';
 import { MixPanelEvents, MixPanelProvider, useMixpanel } from './hooks/mixpanel';
 import i18n, { availableLanguages } from './i18n';
 import store, { PANGOLIN_PERSISTED_KEYS, StoreContext, galetoStore, pangolinReducers } from './state';
@@ -63,6 +83,7 @@ import { useSarPositionsHook } from './state/psarstake/multiChainsHooks';
 import { Position } from './state/psarstake/types';
 import SwapUpdater from './state/pswap/updater';
 import { default as ThemeProvider } from './theme';
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -124,6 +145,7 @@ export function PangolinProvider({
 }
 
 export * from './constants';
+export * from './constants/lists';
 export * from './connectors';
 export * from './components';
 export * from './state/papplication/hooks';
@@ -177,6 +199,19 @@ export {
   useUSDCPriceHook,
   useParsedQueryString,
   useMixpanel,
+  useTokenAllowance,
+  useCoinGeckoTokenData,
+  useDebounce,
+  useOnClickOutside,
+  useInterval,
+  useIsWindowVisible,
+  useENS,
+  usePngContract,
+  useStakingContract,
+  useMulticallContract,
+  usePairContract,
+  useTokenContract,
+  useContract,
 };
 
 // misc
@@ -184,6 +219,8 @@ export {
   pangolinReducers,
   PANGOLIN_PERSISTED_KEYS,
   wrappedCurrency,
+  wrappedCurrencyAmount,
+  unwrappedToken,
   nearFn,
   i18n,
   availableLanguages,
@@ -198,4 +235,9 @@ export {
   shortenAddress,
   shortenAddressMapping,
   MixPanelEvents,
+  chunkArray,
+  uriToHttp,
+  parseENSAddress,
+  listVersionLabel,
+  splitQuery,
 };


### PR DESCRIPTION
## Summary
- export more hooks and utils function to re-use it in interface repo
