### PR TITLE
fix: hedera & some ui bugs

### DIFF
--- a/src/components/Pools/AddLiquidity/index.tsx
+++ b/src/components/Pools/AddLiquidity/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Currency, TokenAmount } from '@pangolindex/sdk';
+import { Currency, Pair, TokenAmount } from '@pangolindex/sdk';
 import React, { useCallback, useContext, useState } from 'react';
 import { Plus } from 'react-feather';
 import { useTranslation } from 'react-i18next';
@@ -42,8 +42,13 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
 
   const expertMode = useIsExpertMode();
 
+  const wrappedCurrencyA = wrappedCurrency(currencyA, chainId);
+  const wrappedCurrencyB = wrappedCurrency(currencyB, chainId);
+
+  const pairAddress = wrappedCurrencyA && wrappedCurrencyB ? Pair.getAddress(wrappedCurrencyA, wrappedCurrencyB) : '';
+
   // mint state
-  const { independentField, typedValue, otherTypedValue } = useMintState();
+  const { independentField, typedValue, otherTypedValue } = useMintState(pairAddress);
   const {
     dependentField,
     currencies,
@@ -151,7 +156,7 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
     setShowConfirm(false);
     // if there was a tx hash, we want to clear the input
     if (txHash) {
-      onFieldAInput('');
+      onFieldAInput('', pairAddress);
     }
     setTxHash('');
     setAttemptingTxn(false);
@@ -159,13 +164,13 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
 
   const handleTypeInput = useCallback(
     (value: string) => {
-      onFieldAInput(value);
+      onFieldAInput(value, pairAddress);
     },
     [onFieldAInput],
   );
   const handleTypeOutput = useCallback(
     (value: string) => {
-      onFieldBInput(value);
+      onFieldBInput(value, pairAddress);
     },
     [onFieldBInput],
   );
@@ -245,7 +250,9 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
             addonAfter={
               !atMaxAmounts[Field.CURRENCY_A] ? (
                 <Box display={'flex'} alignItems={'center'} height={'100%'} justifyContent={'center'}>
-                  <StyledBalanceMax onClick={() => onFieldAInput(maxAmounts[Field.CURRENCY_A]?.toExact() ?? '')}>
+                  <StyledBalanceMax
+                    onClick={() => onFieldAInput(maxAmounts[Field.CURRENCY_A]?.toExact() ?? '', pairAddress)}
+                  >
                     {t('currencyInputPanel.max')}
                   </StyledBalanceMax>
                 </Box>
@@ -287,7 +294,9 @@ const AddLiquidity = ({ currencyA, currencyB, onComplete, onAddToFarm, type }: A
             addonAfter={
               !atMaxAmounts[Field.CURRENCY_B] ? (
                 <Box display={'flex'} alignItems={'center'} height={'100%'} justifyContent={'center'}>
-                  <StyledBalanceMax onClick={() => onFieldBInput(maxAmounts[Field.CURRENCY_B]?.toExact() ?? '')}>
+                  <StyledBalanceMax
+                    onClick={() => onFieldBInput(maxAmounts[Field.CURRENCY_B]?.toExact() ?? '', pairAddress)}
+                  >
                     {t('currencyInputPanel.max')}
                   </StyledBalanceMax>
                 </Box>

--- a/src/components/Pools/DetailModal/index.tsx
+++ b/src/components/Pools/DetailModal/index.tsx
@@ -1,3 +1,4 @@
+import { Pair } from '@pangolindex/sdk';
 import React, { useCallback, useContext, useEffect } from 'react';
 import { ThemeContext } from 'styled-components';
 import { Modal } from 'src/components';
@@ -21,8 +22,13 @@ const DetailModal = ({ stakingInfo, version }: DetailModalProps) => {
 
   const dispatch = useDispatch();
 
+  const pairAddress =
+    stakingInfo?.tokens?.[0] && stakingInfo?.tokens?.[1]
+      ? Pair.getAddress(stakingInfo.tokens[0], stakingInfo.tokens[1])
+      : '';
+
   useEffect(() => {
-    dispatch(resetMintState());
+    dispatch(resetMintState({ pairAddress: pairAddress }));
   }, [detailModalOpen, dispatch]);
 
   const handleOnDismiss = useCallback(() => {

--- a/src/components/Pools/PangoChef/Compound/index.tsx
+++ b/src/components/Pools/PangoChef/Compound/index.tsx
@@ -302,7 +302,7 @@ const CompoundV3 = ({ stakingInfo, onClose }: CompoundProps) => {
         value={formatUnits(amountToAdd.raw.toString(), tokenOrCurrency.decimals)}
       />
       <WarningMessageWrapper>
-        <Text color="text1" textAlign="center" fontSize="12px">
+        <Text color="text1" textAlign="center" fontSize="10px">
           {message}
         </Text>
         <Tooltip id="help" effect="solid" backgroundColor={theme.primary} place="left">

--- a/src/components/Pools/PangoChef/Stake/ConfirmDrawer.tsx
+++ b/src/components/Pools/PangoChef/Stake/ConfirmDrawer.tsx
@@ -83,7 +83,7 @@ const ConfirmDrawer: React.FC<Props> = (props) => {
 
   const confirmContent = (
     <ContentWrapper>
-      <Box display="flex" justifyContent="space-between" width="100%">
+      <Box display="flex" justifyContent="space-between" width="100%" alignItems="center">
         <Text fontSize={type === SpaceType.card ? '20px' : '28px'} fontWeight={500} color="text1">
           {amount ? amount?.toSignificant(6) : 0} PGL
         </Text>
@@ -108,11 +108,9 @@ const ConfirmDrawer: React.FC<Props> = (props) => {
           share of the rewards you’ll get.
         </Text>
       </Box>
-      <Box alignSelf="flex-end">
-        <Button variant="primary" onClick={onStake}>
-          Stake
-        </Button>
-      </Box>
+      <Button variant="primary" onClick={onStake}>
+        Stake
+      </Button>
     </ContentWrapper>
   );
 

--- a/src/components/Pools/PangoChef/Stake/index.tsx
+++ b/src/components/Pools/PangoChef/Stake/index.tsx
@@ -263,7 +263,7 @@ const Stake = ({ onComplete, type, stakingInfo, combinedApr }: StakeProps) => {
       : '-';
 
   const renderButton = () => {
-    if (shouldCreateStorage) {
+    if (shouldCreateStorage && !error) {
       return (
         <>
           <Tooltip id="storageContract" effect="solid" backgroundColor={theme.primary}>
@@ -295,7 +295,7 @@ const Stake = ({ onComplete, type, stakingInfo, combinedApr }: StakeProps) => {
 
           <Button
             variant="primary"
-            isDisabled={!!error || approval !== ApprovalState.APPROVED || !!stakeCallbackError}
+            isDisabled={!!error || approval !== ApprovalState.APPROVED || !!stakeCallbackError || shouldCreateStorage}
             onClick={onConfirm}
             loading={attempting && !hash}
             loadingText={t('migratePage.loading')}

--- a/src/components/Pools/PangoChef/Stake/styleds.tsx
+++ b/src/components/Pools/PangoChef/Stake/styleds.tsx
@@ -103,8 +103,8 @@ export const SubmittedWrapper = styled(Box)`
 
 export const ContentWrapper = styled(Box)`
   display: grid;
-  grid-gap: 20px;
-  padding: 20px;
+  grid-gap: 10px;
+  padding: 0px 20px 10px 20px;
   height: 100%;
 `;
 

--- a/src/components/Pools/RemoveFarm/index.tsx
+++ b/src/components/Pools/RemoveFarm/index.tsx
@@ -1,4 +1,4 @@
-import { CHAINS, ChefType } from '@pangolindex/sdk';
+import { CHAINS, ChefType, Pair, TokenAmount } from '@pangolindex/sdk';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, Button, Loader, Stat, Text, TransactionCompleted } from 'src/components';
@@ -45,7 +45,18 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoadingOrComplete, redire
 
   const mixpanel = useMixpanel();
 
-  const notAssociateTokens = useGetHederaTokenNotAssociated(rewardTokens || []);
+  const dummyPair = new Pair(
+    new TokenAmount(stakingInfo?.tokens?.[0], '0'),
+    new TokenAmount(stakingInfo?.tokens?.[1], '0'),
+    chainId,
+  );
+  const lpToken = dummyPair.liquidityToken;
+
+  const associatedTokens = rewardTokens || [];
+  // we need to check the lp token too
+  // because case a user farm in non Pangolin token/Wrapped token farm and compound to this farm
+  // in compoundTo
+  const notAssociateTokens = useGetHederaTokenNotAssociated([...associatedTokens, lpToken]);
   // here we get all not associated rewards tokens
   // but we associate one token at a time
   // so we get first token from array and ask user to associate

--- a/src/components/SarManageWidget/AddStake/index.tsx
+++ b/src/components/SarManageWidget/AddStake/index.tsx
@@ -88,6 +88,11 @@ export default function AddStake({ selectedOption, selectedPosition, onChange, o
     }
   }, [approval, approvalSubmitted]);
 
+  // if changed the position and the drawer is open, close
+  useEffect(() => {
+    if (openDrawer) setOpenDrawer(false);
+  }, [selectedPosition]);
+
   const handleConfirmDismiss = useCallback(() => {
     setOpenDrawer(false);
     // if there was a tx hash, we want to clear the input

--- a/src/components/SarManageWidget/Compound/index.tsx
+++ b/src/components/SarManageWidget/Compound/index.tsx
@@ -71,6 +71,11 @@ export default function Compound({ selectedOption, selectedPosition, onChange, o
     }
   }, [attempting]);
 
+  // if changed the position and the drawer is open, close
+  useEffect(() => {
+    if (openDrawer) setOpenDrawer(false);
+  }, [selectedPosition]);
+
   const renderButton = () => {
     let error: string | undefined;
     if (!selectedPosition) {

--- a/src/components/SwapWidget/SelectTokenDrawer/index.tsx
+++ b/src/components/SwapWidget/SelectTokenDrawer/index.tsx
@@ -8,6 +8,7 @@ import { useChainId } from 'src/hooks';
 import { useAllTokens, useToken } from 'src/hooks/Tokens';
 import usePrevious from 'src/hooks/usePrevious';
 import { useSelectedListInfo } from 'src/state/plists/hooks';
+import { useAddUserToken } from 'src/state/puser/hooks';
 import { filterTokenOrChain, isAddress } from 'src/utils';
 import { Box, Text, TextInput } from '../../';
 import { useTokenComparator } from '../SearchModal/sorting';
@@ -42,6 +43,8 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const lastOpen = usePrevious(isOpen);
+
+  const addToken = useAddUserToken();
 
   useEffect(() => {
     if (isOpen && !lastOpen) {
@@ -108,6 +111,10 @@ const SelectTokenDrawer: React.FC<Props> = (props) => {
   const onSelect = useCallback(
     (currency) => {
       onCurrencySelect(currency);
+      // workaround for now, if it's a custom token we will force add it
+      if (currency && !allTokens[currency?.address || '']) {
+        addToken(currency);
+      }
       onClose();
     },
     [onCurrencySelect, onClose],

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -315,6 +315,7 @@ export function useGetAllHederaAssociatedTokens(dependancies = [] as any[]) {
     {
       keepPreviousData: true,
       refetchInterval: 1000 * 60, // 1 minute
+      enabled: hederaFn.isHederaChain(chainId), // only fetch if the chain id is hedera
     },
   );
 
@@ -386,7 +387,11 @@ export function useGetHederaTokenNotAssociated(tokens: Array<Token> | undefined)
   const { data, isLoading } = useGetAllHederaAssociatedTokens();
 
   return useMemo(() => {
-    return (tokens || []).reduce<Array<Token>>((memo, token) => {
+    if (!tokens) {
+      return [];
+    }
+
+    return tokens.reduce<Array<Token>>((memo, token) => {
       if (token?.address) {
         const currencyId = account ? hederaFn.hederaId(token?.address) : '';
 

--- a/src/hooks/Tokens.ts
+++ b/src/hooks/Tokens.ts
@@ -314,6 +314,7 @@ export function useGetAllHederaAssociatedTokens(dependancies = [] as any[]) {
     },
     {
       keepPreviousData: true,
+      refetchInterval: 1000 * 60, // 1 minute
     },
   );
 

--- a/src/state/pmint/actions.ts
+++ b/src/state/pmint/actions.ts
@@ -5,5 +5,6 @@ export enum Field {
   CURRENCY_B = 'CURRENCY_B',
 }
 
-export const typeInput = createAction<{ field: Field; typedValue: string; noLiquidity: boolean }>('mint/typeInputMint');
-export const resetMintState = createAction<void>('mint/resetMintState');
+export const typeInput =
+  createAction<{ pairAddress: string; field: Field; typedValue: string; noLiquidity: boolean }>('mint/typeInputMint');
+export const resetMintState = createAction<{ pairAddress: string }>('mint/resetMintState');

--- a/src/state/pmint/hooks.ts
+++ b/src/state/pmint/hooks.ts
@@ -19,11 +19,18 @@ import { wrappedCurrency, wrappedCurrencyAmount } from '../../utils/wrappedCurre
 import { tryParseAmount } from '../pswap/hooks';
 import { useCurrencyBalances } from '../pwallet/hooks';
 import { Field, typeInput } from './actions';
+import { initialKeyState } from './reducer';
 
 const ZERO = JSBI.BigInt(0);
 
-export function useMintState(): AppState['pmint'] {
-  return useSelector<AppState['pmint']>((state) => state.pmint);
+export function useMintState(pairAddress: string) {
+  return useSelector<AppState['pmint']['any']>((state) => {
+    const pairState = state.pmint[pairAddress];
+    if (pairState) {
+      return pairState;
+    }
+    return initialKeyState;
+  });
 }
 
 export function useDerivedMintInfo(
@@ -48,7 +55,12 @@ export function useDerivedMintInfo(
 
   const { t } = useTranslation();
 
-  const { independentField, typedValue, otherTypedValue } = useMintState();
+  const wrappedCurrencyA = wrappedCurrency(currencyA, chainId);
+  const wrappedCurrencyB = wrappedCurrency(currencyB, chainId);
+
+  const pairAddress = wrappedCurrencyA && wrappedCurrencyB ? Pair.getAddress(wrappedCurrencyA, wrappedCurrencyB) : '';
+
+  const { independentField, typedValue, otherTypedValue } = useMintState(pairAddress);
 
   const dependentField = independentField === Field.CURRENCY_A ? Field.CURRENCY_B : Field.CURRENCY_A;
 
@@ -98,7 +110,7 @@ export function useDerivedMintInfo(
     } else if (independentAmount) {
       // we wrap the currencies just to get the price in terms of the other token
       const wrappedIndependentAmount = wrappedCurrencyAmount(independentAmount, chainId);
-      const [tokenA, tokenB] = [wrappedCurrency(currencyA, chainId), wrappedCurrency(currencyB, chainId)];
+      const [tokenA, tokenB] = [wrappedCurrencyA, wrappedCurrencyB];
       if (tokenA && tokenB && wrappedIndependentAmount && pair && chainId) {
         const dependentCurrency = dependentField === Field.CURRENCY_B ? currencyB : currencyA;
         const dependentTokenAmount =
@@ -143,13 +155,11 @@ export function useDerivedMintInfo(
       }
       return undefined;
     } else {
-      const wrappedCurrencyA = wrappedCurrency(currencyA, chainId);
-      const wrappedCurrencyB = wrappedCurrency(currencyB, chainId);
       return pair && wrappedCurrencyA && wrappedCurrencyB
         ? pair.priceOf(wrappedCurrencyA, wrappedCurrencyB)
         : undefined;
     }
-  }, [chainId, currencyA, currencyB, noLiquidity, pair, parsedAmounts]);
+  }, [chainId, currencyA, currencyB, noLiquidity, pair, parsedAmounts, wrappedCurrencyA, wrappedCurrencyB]);
 
   // liquidity minted
   const liquidityMinted = useMemo(() => {
@@ -226,20 +236,24 @@ export function useDerivedMintInfo(
 }
 
 export function useMintActionHandlers(noLiquidity: boolean | undefined): {
-  onFieldAInput: (typedValue: string) => void;
-  onFieldBInput: (typedValue: string) => void;
+  onFieldAInput: (typedValue: string, pairAddress: string) => void;
+  onFieldBInput: (typedValue: string, pairAddress: string) => void;
 } {
   const dispatch = useDispatch();
 
   const onFieldAInput = useCallback(
-    (typedValue: string) => {
-      dispatch(typeInput({ field: Field.CURRENCY_A, typedValue, noLiquidity: noLiquidity === true }));
+    (typedValue: string, pairAddress: string) => {
+      dispatch(
+        typeInput({ pairAddress: pairAddress, field: Field.CURRENCY_A, typedValue, noLiquidity: noLiquidity === true }),
+      );
     },
     [dispatch, noLiquidity],
   );
   const onFieldBInput = useCallback(
-    (typedValue: string) => {
-      dispatch(typeInput({ field: Field.CURRENCY_B, typedValue, noLiquidity: noLiquidity === true }));
+    (typedValue: string, pairAddress: string) => {
+      dispatch(
+        typeInput({ pairAddress: pairAddress, field: Field.CURRENCY_B, typedValue, noLiquidity: noLiquidity === true }),
+      );
     },
     [dispatch, noLiquidity],
   );

--- a/src/state/pmint/reducer.ts
+++ b/src/state/pmint/reducer.ts
@@ -2,46 +2,57 @@ import { createReducer } from '@reduxjs/toolkit';
 import { Field, resetMintState, typeInput } from './actions';
 
 export interface MintState {
-  readonly independentField: Field;
-  readonly typedValue: string;
-  readonly otherTypedValue: string; // for the case when there's no liquidity
+  [x: string]: {
+    // the key is the pair address or contract address
+    readonly independentField: Field;
+    readonly typedValue: string;
+    readonly otherTypedValue: string; // for the case when there's no liquidity
+  };
 }
 
-const initialState: MintState = {
+export const initialKeyState = {
   independentField: Field.CURRENCY_A,
   typedValue: '',
   otherTypedValue: '',
 };
 
+const initialState: MintState = {};
+
 export default createReducer<MintState>(initialState, (builder) =>
   builder
-    .addCase(resetMintState, () => initialState)
-    .addCase(typeInput, (state, { payload: { field, typedValue, noLiquidity } }) => {
+    .addCase(resetMintState, (state, { payload: { pairAddress } }) => {
+      state[pairAddress] = initialKeyState;
+      return state;
+    })
+    .addCase(typeInput, (state, { payload: { pairAddress, field, typedValue, noLiquidity } }) => {
+      const pairState = state[pairAddress] ? { ...state[pairAddress] } : initialKeyState;
       if (noLiquidity) {
-        // they're typing into the field they've last typed in
-        if (field === state.independentField) {
-          return {
-            ...state,
+        if (field === pairState.independentField) {
+          state[pairAddress] = {
+            ...pairState,
             independentField: field,
             typedValue,
           };
+          return state;
         }
         // they're typing into a new field, store the other value
         else {
-          return {
-            ...state,
+          state[pairAddress] = {
+            ...pairState,
             independentField: field,
             typedValue,
-            otherTypedValue: state.typedValue,
+            otherTypedValue: pairState.typedValue,
           };
+          return state;
         }
       } else {
-        return {
-          ...state,
+        state[pairAddress] = {
+          ...pairState,
           independentField: field,
           typedValue,
           otherTypedValue: '',
         };
+        return state;
       }
     }),
 );

--- a/src/state/pwallet/hooks.ts
+++ b/src/state/pwallet/hooks.ts
@@ -35,7 +35,6 @@ import {
   useHederaTokenAssociated,
   useNearTokens,
 } from 'src/hooks/Tokens';
-import { useTokensHook } from 'src/hooks/multiChainsHooks';
 import { ApprovalState } from 'src/hooks/useApproveCallback';
 import { useMulticallContract, usePairContract } from 'src/hooks/useContract';
 import { useGetTransactionSignature } from 'src/hooks/useGetTransactionSignature';
@@ -1285,7 +1284,6 @@ export function useGetUserLP() {
 export function useGetHederaUserLP() {
   const chainId = useChainId();
 
-  const useTokens = useTokensHook[chainId];
   // get all pairs
   const trackedTokenPairs = useTrackedTokenPairs();
 
@@ -1325,40 +1323,27 @@ export function useGetHederaUserLP() {
   const tokensMetadata = useHederaTokensMetaData(Object.keys(tokenBalances));
 
   // filter to only fungible tokens
+  // and we need to get token data to do filter based on PGL Symbol
   const allTokensAddress: string[] = useMemo(() => {
     const _allTokensAddress: string[] = [];
     Object.entries(tokensMetadata).forEach(([address, metadata]) => {
-      if (metadata && metadata.type.startsWith('FUNGIBLE')) {
+      if (metadata && metadata.type.startsWith('FUNGIBLE') && metadata.symbol === 'PGL') {
         return _allTokensAddress.push(address);
       }
     });
     return _allTokensAddress;
   }, [tokensMetadata]);
 
-  // here we need to get token data to do filter based on PGL Symbol
-  const tokens = useTokens(allTokensAddress);
-
-  //here we need to filter hedera pair with check of associated
-  const associatedPglAddress = (tokens || [])
-    .map((token) => {
-      if (token?.symbol === 'PGL') {
-        return token.address;
-      }
-    })
-    .filter((element) => {
-      return !!element;
-    });
-
   // here we will filter pairTokens based on associated pgl Address has pgl address
   const filterPairTokens = useMemo(
     () =>
       Object.keys(pglTokenAddresses).reduce<[Token, Token][]>((memo, lpAddress) => {
-        if (associatedPglAddress.includes(pglTokenAddresses[lpAddress])) {
+        if (allTokensAddress.includes(pglTokenAddresses[lpAddress] ?? '')) {
           memo.push(pairTokens[lpAddress]);
         }
         return memo;
       }, []),
-    [pglTokenAddresses, associatedPglAddress, pairTokens],
+    [pglTokenAddresses, allTokensAddress, pairTokens],
   );
 
   const allPairs = usePairs(filterPairTokens);


### PR DESCRIPTION
## Summary

- Force to add custom token when user select it, this is done so that we can search for pools with tokens that were in the token-list will be easy
- Fixed the message to create storage contract, now it only appears if user pgl greater than 0
- Fixed the all "add liquidity" fields are filled with the same value
- Added refetch interval in useGetAllHederaAssociatedTokens, we need to refetch the data because this function return the balance of associated tokens and when the user makes a swap or remove an lp, this value is not being updated
- Fixed the withdraw issue, we need to check if user is associated with pgl too, because if a user is farming in tokenA/tokenB farm and compound to PBAR/WHBAR farm it will create a lp and if the user remove from tokenA/tokenB and try to remove from PBAR/WHBAR the transaction will fail because the user not have associated the PBAR/WHBAR lp token
- Fixed overflow in stake pgl card
- Fixed overflow in compound the farm 
- Fixed the drawer is open (compound and claim sar single stake) when user change the position
## Tasks

https://app.clickup.com/t/8669g422t
https://app.clickup.com/t/8669g42h1
https://app.clickup.com/t/8669hj0x4
https://app.clickup.com/t/8669hj0xe
https://app.clickup.com/t/8669gf6p0