### PR TITLE
fix: hedera pair total supply with api

### DIFF
--- a/src/data/TotalSupply.ts
+++ b/src/data/TotalSupply.ts
@@ -3,7 +3,7 @@ import { ChainId, Pair, Token, TokenAmount } from '@pangolindex/sdk';
 import { useEffect, useMemo, useState } from 'react';
 import { useSubgraphPairs } from 'src/apollo/pairs';
 import { useChainId } from 'src/hooks';
-import { useHederaTokensMetaData } from 'src/state/pwallet/hooks/hedera';
+import { useHederaPGLTokenAddresses, useHederaTokensMetaData } from 'src/state/pwallet/hooks/hedera';
 import { nearFn } from 'src/utils/near';
 import { PNG } from '../constants/tokens';
 import { useTokenContract } from '../hooks/useContract';
@@ -94,6 +94,33 @@ export function useNearPairTotalSupply(pair?: Pair): TokenAmount | undefined {
   }, [pair, chainId]);
 
   return useMemo(() => totalSupply, [totalSupply]);
+}
+
+/**
+ * this hook is used to fetch total supply of given pair
+ * @param pair pair object
+ * @returns total supply in form of TokenAmount or undefined
+ */
+export function useHederaPairTotalSupply(pair?: Pair): TokenAmount | undefined {
+  const token = pair?.liquidityToken;
+
+  const lpTokenAddresses = token?.address;
+
+  const pglTokenAddresses = useHederaPGLTokenAddresses([lpTokenAddresses]);
+
+  const tokensMetadata = useHederaTokensMetaData([lpTokenAddresses ? pglTokenAddresses[lpTokenAddresses] : undefined]);
+
+  return useMemo(() => {
+    if (!token || !lpTokenAddresses || !pglTokenAddresses || !tokensMetadata) {
+      return undefined;
+    }
+
+    const pglTokenAddress = pglTokenAddresses[lpTokenAddresses];
+
+    const totalSupply = pglTokenAddress ? tokensMetadata[pglTokenAddress]?.totalSupply : '0';
+
+    return token && totalSupply ? new TokenAmount(token, totalSupply.toString()) : undefined;
+  }, [token, lpTokenAddresses, tokensMetadata, pglTokenAddresses]);
 }
 
 /**

--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -4,6 +4,7 @@ import { useTokenAllowance } from './Allowances';
 import { useHederaPairs, useNearPairs, usePairs } from './Reserves';
 import {
   useEvmPairTotalSupply,
+  useHederaPairTotalSupply,
   useHederaTotalSupply,
   useNearPairTotalSupply,
   useNearTotalSupply,
@@ -131,6 +132,7 @@ export type UsePairTotalSupplyHookType = {
     | typeof useEvmPairTotalSupply
     | typeof useNearPairTotalSupply
     | typeof usePairTotalSupplyViaSubgraph
+    | typeof useHederaPairTotalSupply
     | typeof useDummyHook;
 };
 
@@ -146,8 +148,8 @@ export const usePairTotalSupplyHook: UsePairTotalSupplyHookType = {
   [ChainId.COSTON]: useEvmPairTotalSupply,
   [ChainId.SONGBIRD]: useEvmPairTotalSupply,
   [ChainId.FLARE_MAINNET]: useEvmPairTotalSupply,
-  [ChainId.HEDERA_TESTNET]: usePairTotalSupplyViaSubgraph,
-  [ChainId.HEDERA_MAINNET]: usePairTotalSupplyViaSubgraph,
+  [ChainId.HEDERA_TESTNET]: useHederaPairTotalSupply,
+  [ChainId.HEDERA_MAINNET]: useHederaPairTotalSupply,
   [ChainId.NEAR_MAINNET]: useNearPairTotalSupply,
   [ChainId.NEAR_TESTNET]: useNearPairTotalSupply,
   [ChainId.COSTON2]: useEvmPairTotalSupply,


### PR DESCRIPTION
## Summary
1. Hedera Pair Totalsupply  with use of api 
2. replace hook  usePairTotalSupplyViaSubgraph with useHederaPairTotalSupply
