### PR TITLE
fix: hedera claim and remove farm associate pbar

### DIFF
--- a/src/components/Pools/PangoChef/ClaimReward/index.tsx
+++ b/src/components/Pools/PangoChef/ClaimReward/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { AlertTriangle } from 'react-feather';
 import { useTranslation } from 'react-i18next';
 import { ThemeContext } from 'styled-components';
@@ -38,7 +38,14 @@ const ClaimRewardV3 = ({ stakingInfo, onClose, redirectToCompound }: ClaimProps)
   const rewardTokens = useGetRewardTokens(stakingInfo);
   const mixpanel = useMixpanel();
 
-  const notAssociateTokens = useGetHederaTokenNotAssociated(rewardTokens || []);
+  // need to check pbar as reward token associate
+  const tokensToCheck = useMemo(() => {
+    // add png in first position
+    const filteredTokens = (rewardTokens || []).filter((token) => !!token && !token.equals(png));
+    return [png, ...filteredTokens];
+  }, [rewardTokens, chainId]);
+
+  const notAssociateTokens = useGetHederaTokenNotAssociated(tokensToCheck || []);
 
   // here we get all not associated rewards tokens
   // but we associate one token at a time

--- a/src/components/Pools/RemoveFarm/index.tsx
+++ b/src/components/Pools/RemoveFarm/index.tsx
@@ -61,8 +61,12 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoading, onComplete, redi
   // because case a user farm in non Pangolin token/Wrapped token farm and compound to this farm
   // in compoundTo
   const tokensToCheck = useMemo(() => {
+    // add png in first position
+    const filteredTokens = (rewardTokens || []).filter((token) => !!token && !token.equals(png));
+    const _rewardTokens = [png, ...filteredTokens];
+
     if (hederaFn.isHederaChain(chainId)) {
-      return [...(rewardTokens || []), pglToken].filter((item) => !!item) as Token[];
+      return [...(_rewardTokens || []), pglToken].filter((item) => !!item) as Token[];
     }
     return undefined;
   }, [rewardTokens, pglToken, hederaFn, chainId]);


### PR DESCRIPTION
## Summary
if PBAR not associated and when user remove farm or claim they get PBAR as reward token so need to that associate first before withdraw and claim 
