### PR TITLE
fix: hedera subgraph hooks dynamically switch

### DIFF
--- a/src/components/Pools/PoolCard/PoolCardV1.tsx
+++ b/src/components/Pools/PoolCard/PoolCardV1.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTokens } from 'src/hooks/tokens/evm';
+import { useTokensContract } from 'src/hooks/tokens/evm';
 import { DoubleSideStakingInfo } from 'src/state/pstake/types';
 import PoolCardView from './PoolCardView';
 
@@ -10,7 +10,7 @@ export interface PoolCardV1Props {
 }
 
 const PoolCardV1 = ({ stakingInfo, onClickViewDetail, version }: PoolCardV1Props) => {
-  const rewardTokens = useTokens(stakingInfo?.rewardTokensAddress);
+  const rewardTokens = useTokensContract(stakingInfo?.rewardTokensAddress);
 
   return (
     <PoolCardView

--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { useQuery } from 'react-query';
 import { useSubgraphPairs } from 'src/apollo/pairs';
 import { useChainId } from 'src/hooks';
+import { useShouldUseSubgraph } from 'src/state/papplication/hooks';
 import { nearFn } from 'src/utils/near';
 import { useMultipleContractSingleData } from '../state/pmulticall/hooks';
 import { wrappedCurrency } from '../utils/wrappedCurrency';
@@ -174,7 +175,9 @@ export function useGetNearPoolId(tokenA?: Token, tokenB?: Token): number | null 
   }, [allPools?.data, allPools?.isLoading, tokenA, tokenB]);
 }
 
-export function useHederaPairs(currencies: [Currency | undefined, Currency | undefined][]): [PairState, Pair | null][] {
+export function usePairsViaSubgraph(
+  currencies: [Currency | undefined, Currency | undefined][],
+): [PairState, Pair | null][] {
   const chainId = useChainId();
 
   const tokens = useMemo(
@@ -234,3 +237,10 @@ export function useHederaPairs(currencies: [Currency | undefined, Currency | und
     });
   }, [results, tokens, chainId, results?.data, results?.isLoading, pairReserves]);
 }
+
+export const useHederaPairs = (currencies: [Currency | undefined, Currency | undefined][]) => {
+  const shouldUseSubgraph = useShouldUseSubgraph();
+  const useHook = shouldUseSubgraph ? usePairsViaSubgraph : usePairs;
+  const res = useHook(currencies);
+  return res;
+};

--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -238,9 +238,14 @@ export function usePairsViaSubgraph(
   }, [results, tokens, chainId, results?.data, results?.isLoading, pairReserves]);
 }
 
-export const useHederaPairs = (currencies: [Currency | undefined, Currency | undefined][]) => {
+/**
+ * its wrapper hook to check which hook need to use based on subgraph on off
+ * @param currencies
+ * @returns
+ */
+export function useHederaPairs(currencies: [Currency | undefined, Currency | undefined][]) {
   const shouldUseSubgraph = useShouldUseSubgraph();
   const useHook = shouldUseSubgraph ? usePairsViaSubgraph : usePairs;
   const res = useHook(currencies);
   return res;
-};
+}

--- a/src/data/Reserves.ts
+++ b/src/data/Reserves.ts
@@ -27,7 +27,9 @@ export enum PoolType {
   RATED_SWAP = 'RATED_SWAP',
 }
 
-export function usePairs(currencies: [Currency | undefined, Currency | undefined][]): [PairState, Pair | null][] {
+export function usePairsContract(
+  currencies: [Currency | undefined, Currency | undefined][],
+): [PairState, Pair | null][] {
   const chainId = useChainId();
 
   const tokens = useMemo(
@@ -243,9 +245,9 @@ export function usePairsViaSubgraph(
  * @param currencies
  * @returns
  */
-export function useHederaPairs(currencies: [Currency | undefined, Currency | undefined][]) {
+export function usePairs(currencies: [Currency | undefined, Currency | undefined][]) {
   const shouldUseSubgraph = useShouldUseSubgraph();
-  const useHook = shouldUseSubgraph ? usePairsViaSubgraph : usePairs;
+  const useHook = shouldUseSubgraph ? usePairsViaSubgraph : usePairsContract;
   const res = useHook(currencies);
   return res;
 }

--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@pangolindex/sdk';
 import { useDummyHook } from 'src/hooks/multiChainsHooks';
 import { useTokenAllowance } from './Allowances';
-import { useHederaPairs, useNearPairs, usePairs, usePairsViaSubgraph } from './Reserves';
+import { useNearPairs, usePairs, usePairsContract, usePairsViaSubgraph } from './Reserves';
 import {
   useEvmPairTotalSupply,
   useHederaPairTotalSupply,
@@ -13,39 +13,39 @@ import {
 } from './TotalSupply';
 
 export type UsePairsHookType = {
-  [chainId in ChainId]: typeof usePairs | typeof useNearPairs | typeof usePairsViaSubgraph | typeof useHederaPairs;
+  [chainId in ChainId]: typeof usePairsContract | typeof useNearPairs | typeof usePairsViaSubgraph | typeof usePairs;
 };
 
 export const usePairsHook: UsePairsHookType = {
-  [ChainId.FUJI]: usePairs,
-  [ChainId.AVALANCHE]: usePairs,
-  [ChainId.WAGMI]: usePairs,
-  [ChainId.COSTON]: usePairs,
-  [ChainId.SONGBIRD]: usePairs,
-  [ChainId.FLARE_MAINNET]: usePairs,
-  [ChainId.HEDERA_TESTNET]: useHederaPairs,
-  [ChainId.HEDERA_MAINNET]: useHederaPairs,
+  [ChainId.FUJI]: usePairsContract,
+  [ChainId.AVALANCHE]: usePairsContract,
+  [ChainId.WAGMI]: usePairsContract,
+  [ChainId.COSTON]: usePairsContract,
+  [ChainId.SONGBIRD]: usePairsContract,
+  [ChainId.FLARE_MAINNET]: usePairsContract,
+  [ChainId.HEDERA_TESTNET]: usePairs,
+  [ChainId.HEDERA_MAINNET]: usePairs,
   [ChainId.NEAR_MAINNET]: useNearPairs,
   [ChainId.NEAR_TESTNET]: useNearPairs,
-  [ChainId.COSTON2]: usePairs,
-  [ChainId.EVMOS_TESTNET]: usePairs,
-  [ChainId.EVMOS_MAINNET]: usePairs,
+  [ChainId.COSTON2]: usePairsContract,
+  [ChainId.EVMOS_TESTNET]: usePairsContract,
+  [ChainId.EVMOS_MAINNET]: usePairsContract,
   //TODO: We used usePairs for now, but we need to check following chains
-  [ChainId.ETHEREUM]: usePairs,
-  [ChainId.POLYGON]: usePairs,
-  [ChainId.FANTOM]: usePairs,
-  [ChainId.XDAI]: usePairs,
-  [ChainId.BSC]: usePairs,
-  [ChainId.ARBITRUM]: usePairs,
-  [ChainId.CELO]: usePairs,
-  [ChainId.OKXCHAIN]: usePairs,
-  [ChainId.VELAS]: usePairs,
-  [ChainId.AURORA]: usePairs,
-  [ChainId.CRONOS]: usePairs,
-  [ChainId.FUSE]: usePairs,
-  [ChainId.MOONRIVER]: usePairs,
-  [ChainId.MOONBEAM]: usePairs,
-  [ChainId.OP]: usePairs,
+  [ChainId.ETHEREUM]: usePairsContract,
+  [ChainId.POLYGON]: usePairsContract,
+  [ChainId.FANTOM]: usePairsContract,
+  [ChainId.XDAI]: usePairsContract,
+  [ChainId.BSC]: usePairsContract,
+  [ChainId.ARBITRUM]: usePairsContract,
+  [ChainId.CELO]: usePairsContract,
+  [ChainId.OKXCHAIN]: usePairsContract,
+  [ChainId.VELAS]: usePairsContract,
+  [ChainId.AURORA]: usePairsContract,
+  [ChainId.CRONOS]: usePairsContract,
+  [ChainId.FUSE]: usePairsContract,
+  [ChainId.MOONRIVER]: usePairsContract,
+  [ChainId.MOONBEAM]: usePairsContract,
+  [ChainId.OP]: usePairsContract,
 };
 
 export type UseTokenAllowanceHookType = {

--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@pangolindex/sdk';
 import { useDummyHook } from 'src/hooks/multiChainsHooks';
 import { useTokenAllowance } from './Allowances';
-import { useHederaPairs, useNearPairs, usePairs } from './Reserves';
+import { useHederaPairs, useNearPairs, usePairs, usePairsViaSubgraph } from './Reserves';
 import {
   useEvmPairTotalSupply,
   useHederaPairTotalSupply,
@@ -13,7 +13,7 @@ import {
 } from './TotalSupply';
 
 export type UsePairsHookType = {
-  [chainId in ChainId]: typeof usePairs | typeof useNearPairs | typeof useHederaPairs;
+  [chainId in ChainId]: typeof usePairs | typeof useNearPairs | typeof usePairsViaSubgraph | typeof useHederaPairs;
 };
 
 export const usePairsHook: UsePairsHookType = {

--- a/src/hooks/multiChainsHooks.ts
+++ b/src/hooks/multiChainsHooks.ts
@@ -3,10 +3,10 @@ import { ChainId } from '@pangolindex/sdk';
 import {
   useDummyTokenCurrencyPrice,
   useDummyTokensCurrencyPrice,
-  useHederaTokensCurrencyPrice,
   useTokenCurrencyPrice,
   useTokenCurrencyPriceSubgraph,
   useTokensCurrencyPrice,
+  useTokensCurrencyPriceContract,
   useTokensCurrencyPriceSubgraph,
 } from './useCurrencyPrice';
 
@@ -19,23 +19,23 @@ export type UseTokensCurrencyPriceHookType = {
     | typeof useTokensCurrencyPrice
     | typeof useTokensCurrencyPriceSubgraph
     | typeof useDummyTokensCurrencyPrice
-    | typeof useHederaTokensCurrencyPrice;
+    | typeof useTokensCurrencyPriceContract;
 };
 
 export const useTokensCurrencyPriceHook: UseTokensCurrencyPriceHookType = {
   [ChainId.FUJI]: useDummyTokensCurrencyPrice,
   [ChainId.AVALANCHE]: useDummyTokensCurrencyPrice,
   [ChainId.WAGMI]: useDummyTokensCurrencyPrice,
-  [ChainId.COSTON]: useTokensCurrencyPrice,
-  [ChainId.SONGBIRD]: useTokensCurrencyPrice,
-  [ChainId.FLARE_MAINNET]: useTokensCurrencyPrice,
-  [ChainId.HEDERA_TESTNET]: useHederaTokensCurrencyPrice,
-  [ChainId.HEDERA_MAINNET]: useHederaTokensCurrencyPrice,
+  [ChainId.COSTON]: useTokensCurrencyPriceContract,
+  [ChainId.SONGBIRD]: useTokensCurrencyPriceContract,
+  [ChainId.FLARE_MAINNET]: useTokensCurrencyPriceContract,
+  [ChainId.HEDERA_TESTNET]: useTokensCurrencyPrice,
+  [ChainId.HEDERA_MAINNET]: useTokensCurrencyPrice,
   [ChainId.NEAR_MAINNET]: useDummyTokensCurrencyPrice,
   [ChainId.NEAR_TESTNET]: useDummyTokensCurrencyPrice,
-  [ChainId.COSTON2]: useTokensCurrencyPrice,
-  [ChainId.EVMOS_TESTNET]: useTokensCurrencyPrice,
-  [ChainId.EVMOS_MAINNET]: useTokensCurrencyPrice,
+  [ChainId.COSTON2]: useTokensCurrencyPriceContract,
+  [ChainId.EVMOS_TESTNET]: useTokensCurrencyPriceContract,
+  [ChainId.EVMOS_MAINNET]: useTokensCurrencyPriceContract,
   [ChainId.ETHEREUM]: useDummyTokensCurrencyPrice,
   [ChainId.POLYGON]: useDummyTokensCurrencyPrice,
   [ChainId.FANTOM]: useDummyTokensCurrencyPrice,

--- a/src/hooks/multiChainsHooks.ts
+++ b/src/hooks/multiChainsHooks.ts
@@ -3,6 +3,7 @@ import { ChainId } from '@pangolindex/sdk';
 import {
   useDummyTokenCurrencyPrice,
   useDummyTokensCurrencyPrice,
+  useHederaTokensCurrencyPrice,
   useTokenCurrencyPrice,
   useTokenCurrencyPriceSubgraph,
   useTokensCurrencyPrice,
@@ -17,7 +18,8 @@ export type UseTokensCurrencyPriceHookType = {
   [chainId in ChainId]:
     | typeof useTokensCurrencyPrice
     | typeof useTokensCurrencyPriceSubgraph
-    | typeof useDummyTokensCurrencyPrice;
+    | typeof useDummyTokensCurrencyPrice
+    | typeof useHederaTokensCurrencyPrice;
 };
 
 export const useTokensCurrencyPriceHook: UseTokensCurrencyPriceHookType = {
@@ -27,8 +29,8 @@ export const useTokensCurrencyPriceHook: UseTokensCurrencyPriceHookType = {
   [ChainId.COSTON]: useTokensCurrencyPrice,
   [ChainId.SONGBIRD]: useTokensCurrencyPrice,
   [ChainId.FLARE_MAINNET]: useTokensCurrencyPrice,
-  [ChainId.HEDERA_TESTNET]: useTokensCurrencyPriceSubgraph,
-  [ChainId.HEDERA_MAINNET]: useTokensCurrencyPriceSubgraph,
+  [ChainId.HEDERA_TESTNET]: useHederaTokensCurrencyPrice,
+  [ChainId.HEDERA_MAINNET]: useHederaTokensCurrencyPrice,
   [ChainId.NEAR_MAINNET]: useDummyTokensCurrencyPrice,
   [ChainId.NEAR_TESTNET]: useDummyTokensCurrencyPrice,
   [ChainId.COSTON2]: useTokensCurrencyPrice,

--- a/src/hooks/tokens/evm.ts
+++ b/src/hooks/tokens/evm.ts
@@ -78,7 +78,7 @@ export function useToken(tokenAddress?: string): TokenReturnType {
   ]);
 }
 
-export function useTokens(tokensAddress: string[] = []): Array<TokenReturnType> | undefined | null {
+export function useTokensContract(tokensAddress: string[] = []): Array<TokenReturnType> | undefined | null {
   const chainId = useChainId();
   const tokens = useAllTokens();
 

--- a/src/hooks/tokens/index.ts
+++ b/src/hooks/tokens/index.ts
@@ -2,7 +2,7 @@ import { ChainId } from '@pangolindex/sdk';
 import { useDummyHook } from 'src/hooks/multiChainsHooks';
 import { useToken, useTokens } from './evm';
 import { useNearToken, useNearTokens } from './near';
-import { useTokensViaSubGraph } from './subgraph';
+import { useHederaTokens, useTokensViaSubGraph } from './subgraph';
 
 export type UseTokenHookType = {
   [chainId in ChainId]: typeof useToken | typeof useNearToken | typeof useDummyHook;
@@ -40,7 +40,12 @@ export const useTokenHook: UseTokenHookType = {
 };
 
 export type UseTokensHookType = {
-  [chainId in ChainId]: typeof useTokens | typeof useNearTokens | typeof useTokensViaSubGraph | typeof useDummyHook;
+  [chainId in ChainId]:
+    | typeof useTokens
+    | typeof useNearTokens
+    | typeof useTokensViaSubGraph
+    | typeof useDummyHook
+    | typeof useHederaTokens;
 };
 
 export const useTokensHook: UseTokensHookType = {
@@ -50,8 +55,8 @@ export const useTokensHook: UseTokensHookType = {
   [ChainId.COSTON]: useTokens,
   [ChainId.SONGBIRD]: useTokens,
   [ChainId.FLARE_MAINNET]: useTokens,
-  [ChainId.HEDERA_TESTNET]: useTokensViaSubGraph,
-  [ChainId.HEDERA_MAINNET]: useTokensViaSubGraph,
+  [ChainId.HEDERA_TESTNET]: useHederaTokens,
+  [ChainId.HEDERA_MAINNET]: useHederaTokens,
   [ChainId.NEAR_MAINNET]: useNearTokens,
   [ChainId.NEAR_TESTNET]: useNearTokens,
   [ChainId.COSTON2]: useTokens,

--- a/src/hooks/tokens/index.ts
+++ b/src/hooks/tokens/index.ts
@@ -1,8 +1,8 @@
 import { ChainId } from '@pangolindex/sdk';
 import { useDummyHook } from 'src/hooks/multiChainsHooks';
-import { useToken, useTokens } from './evm';
+import { useToken, useTokensContract } from './evm';
 import { useNearToken, useNearTokens } from './near';
-import { useHederaTokens, useTokensViaSubGraph } from './subgraph';
+import { useTokens, useTokensViaSubGraph } from './subgraph';
 
 export type UseTokenHookType = {
   [chainId in ChainId]: typeof useToken | typeof useNearToken | typeof useDummyHook;
@@ -41,27 +41,27 @@ export const useTokenHook: UseTokenHookType = {
 
 export type UseTokensHookType = {
   [chainId in ChainId]:
-    | typeof useTokens
+    | typeof useTokensContract
     | typeof useNearTokens
     | typeof useTokensViaSubGraph
     | typeof useDummyHook
-    | typeof useHederaTokens;
+    | typeof useTokens;
 };
 
 export const useTokensHook: UseTokensHookType = {
-  [ChainId.FUJI]: useTokens,
-  [ChainId.AVALANCHE]: useTokens,
-  [ChainId.WAGMI]: useTokens,
-  [ChainId.COSTON]: useTokens,
-  [ChainId.SONGBIRD]: useTokens,
-  [ChainId.FLARE_MAINNET]: useTokens,
-  [ChainId.HEDERA_TESTNET]: useHederaTokens,
-  [ChainId.HEDERA_MAINNET]: useHederaTokens,
+  [ChainId.FUJI]: useTokensContract,
+  [ChainId.AVALANCHE]: useTokensContract,
+  [ChainId.WAGMI]: useTokensContract,
+  [ChainId.COSTON]: useTokensContract,
+  [ChainId.SONGBIRD]: useTokensContract,
+  [ChainId.FLARE_MAINNET]: useTokensContract,
+  [ChainId.HEDERA_TESTNET]: useTokens,
+  [ChainId.HEDERA_MAINNET]: useTokens,
   [ChainId.NEAR_MAINNET]: useNearTokens,
   [ChainId.NEAR_TESTNET]: useNearTokens,
-  [ChainId.COSTON2]: useTokens,
-  [ChainId.EVMOS_TESTNET]: useTokens,
-  [ChainId.EVMOS_MAINNET]: useTokens,
+  [ChainId.COSTON2]: useTokensContract,
+  [ChainId.EVMOS_TESTNET]: useTokensContract,
+  [ChainId.EVMOS_MAINNET]: useTokensContract,
   [ChainId.ETHEREUM]: useDummyHook,
   [ChainId.POLYGON]: useDummyHook,
   [ChainId.FANTOM]: useDummyHook,

--- a/src/hooks/tokens/subgraph.ts
+++ b/src/hooks/tokens/subgraph.ts
@@ -2,10 +2,11 @@ import { Token } from '@pangolindex/sdk';
 import { useMemo } from 'react';
 import { useSubgraphTokens } from 'src/apollo/tokens';
 import { useChainId } from 'src/hooks';
+import { useShouldUseSubgraph } from 'src/state/papplication/hooks';
 import { validateAddressMapping } from 'src/utils';
 import { useAllTokens } from '../useAllTokens';
 import { TokenReturnType } from './constant';
-
+import { useTokens } from './evm';
 /**
  * This hook format the tokens address to token object from sdk
  * @param tokensAddress token address array
@@ -45,3 +46,15 @@ export function useTokensViaSubGraph(tokensAddress: string[] = []): Array<TokenR
     }, []);
   }, [chainId, isLoading, subgraphTokens, tokens, tokensAddress]);
 }
+
+/**
+ * its wrapper hook to check which hook need to use based on subgraph on off
+ * @param tokensAddress
+ * @returns
+ */
+export const useHederaTokens = (tokensAddress: string[] = []): Array<TokenReturnType> | undefined | null => {
+  const shouldUseSubgraph = useShouldUseSubgraph();
+  const useHook = shouldUseSubgraph ? useTokensViaSubGraph : useTokens;
+  const res = useHook(tokensAddress);
+  return res;
+};

--- a/src/hooks/tokens/subgraph.ts
+++ b/src/hooks/tokens/subgraph.ts
@@ -6,7 +6,7 @@ import { useShouldUseSubgraph } from 'src/state/papplication/hooks';
 import { validateAddressMapping } from 'src/utils';
 import { useAllTokens } from '../useAllTokens';
 import { TokenReturnType } from './constant';
-import { useTokens } from './evm';
+import { useTokensContract } from './evm';
 /**
  * This hook format the tokens address to token object from sdk
  * @param tokensAddress token address array
@@ -52,9 +52,9 @@ export function useTokensViaSubGraph(tokensAddress: string[] = []): Array<TokenR
  * @param tokensAddress
  * @returns
  */
-export const useHederaTokens = (tokensAddress: string[] = []): Array<TokenReturnType> | undefined | null => {
+export function useTokens(tokensAddress: string[] = []): Array<TokenReturnType> | undefined | null {
   const shouldUseSubgraph = useShouldUseSubgraph();
-  const useHook = shouldUseSubgraph ? useTokensViaSubGraph : useTokens;
+  const useHook = shouldUseSubgraph ? useTokensViaSubGraph : useTokensContract;
   const res = useHook(tokensAddress);
   return res;
-};
+}

--- a/src/hooks/useCurrencyPrice.ts
+++ b/src/hooks/useCurrencyPrice.ts
@@ -16,7 +16,7 @@ import { useChainId } from '.';
  * @param tokens array of tokens to get the price in wrapped gas coin
  * @returns object where the key is the address of the token and the value is the Price
  */
-export function useTokensCurrencyPrice(tokens: (Token | undefined)[]): { [x: string]: Price } {
+export function useTokensCurrencyPriceContract(tokens: (Token | undefined)[]): { [x: string]: Price } {
   const chainId = useChainId();
 
   const usePairs = usePairsHook[chainId];
@@ -150,12 +150,12 @@ export function useTokenCurrencyPriceSubgraph(token: Token | undefined): Price {
  * @param tokens
  * @returns
  */
-export const useHederaTokensCurrencyPrice = (tokens: (Token | undefined)[]) => {
+export function useTokensCurrencyPrice(tokens: (Token | undefined)[]) {
   const shouldUseSubgraph = useShouldUseSubgraph();
-  const useHook = shouldUseSubgraph ? useTokensCurrencyPriceSubgraph : useTokensCurrencyPrice;
+  const useHook = shouldUseSubgraph ? useTokensCurrencyPriceSubgraph : useTokensCurrencyPriceContract;
   const res = useHook(tokens);
   return res;
-};
+}
 
 /**
  * Returns the tokens price in relation to gas coin hbar

--- a/src/hooks/useCurrencyPrice.ts
+++ b/src/hooks/useCurrencyPrice.ts
@@ -4,6 +4,7 @@ import { useSubgraphTokens } from 'src/apollo/tokens';
 import { ZERO_ADDRESS } from 'src/constants';
 import { PairState, usePair } from 'src/data/Reserves';
 import { usePairsHook } from 'src/data/multiChainsHooks';
+import { useShouldUseSubgraph } from 'src/state/papplication/hooks';
 import { decimalToFraction } from 'src/utils';
 import { hederaFn } from 'src/utils/hedera';
 import { useTokensCurrencyPriceHook } from './multiChainsHooks';
@@ -143,6 +144,18 @@ export function useTokenCurrencyPriceSubgraph(token: Token | undefined): Price {
     return tokenPrice[token?.address];
   }, [tokenPrice, token]);
 }
+
+/**
+ * its wrapper hook to check which hook need to use based on subgraph on off
+ * @param tokens
+ * @returns
+ */
+export const useHederaTokensCurrencyPrice = (tokens: (Token | undefined)[]) => {
+  const shouldUseSubgraph = useShouldUseSubgraph();
+  const useHook = shouldUseSubgraph ? useTokensCurrencyPriceSubgraph : useTokensCurrencyPrice;
+  const res = useHook(tokens);
+  return res;
+};
 
 /**
  * Returns the tokens price in relation to gas coin hbar

--- a/src/hooks/useUSDCPrice/evm.ts
+++ b/src/hooks/useUSDCPrice/evm.ts
@@ -1,7 +1,7 @@
 import { ChainId, Currency, JSBI, Price, WAVAX, currencyEquals } from '@pangolindex/sdk';
 import { useMemo } from 'react';
 import { USDCe } from 'src/constants/tokens';
-import { PairState, usePairs } from 'src/data/Reserves';
+import { PairState, usePairsContract } from 'src/data/Reserves';
 import { wrappedCurrency } from 'src/utils/wrappedCurrency';
 import { useChainId } from '../index';
 
@@ -25,7 +25,7 @@ export function useUSDCPrice(currency?: Currency): Price | undefined {
     [chainId, currency, wrapped, USDC],
   );
   const [[avaxPairState, avaxPair], [usdcPairState, usdcPair], [usdcAvaxPairState, usdcAvaxPair]] =
-    usePairs(tokenPairs);
+    usePairsContract(tokenPairs);
 
   return useMemo(() => {
     if (!currency || !wrapped || !chainId) {

--- a/src/state/papplication/atom.ts
+++ b/src/state/papplication/atom.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@pangolindex/sdk';
 import { TokenList } from '@pangolindex/token-lists';
 import { atom, useAtom } from 'jotai';
 import { nanoid } from 'nanoid';
@@ -33,13 +34,76 @@ export interface ApplicationState {
   readonly openModal: ApplicationModal | null;
   readonly selectedPoolId: string | undefined;
   readonly isAvailableHashpack: boolean;
+
+  readonly useSubgraph: {
+    [ChainId.FUJI]: boolean;
+    [ChainId.AVALANCHE]: boolean;
+    [ChainId.WAGMI]: boolean;
+    [ChainId.COSTON]: boolean;
+    [ChainId.SONGBIRD]: boolean;
+    [ChainId.FLARE_MAINNET]: boolean;
+    [ChainId.HEDERA_TESTNET]: boolean;
+    [ChainId.HEDERA_MAINNET]: boolean;
+    [ChainId.NEAR_MAINNET]: boolean;
+    [ChainId.NEAR_TESTNET]: boolean;
+    [ChainId.COSTON2]: boolean;
+    [ChainId.ETHEREUM]: boolean;
+    [ChainId.POLYGON]: boolean;
+    [ChainId.FANTOM]: boolean;
+    [ChainId.XDAI]: boolean;
+    [ChainId.BSC]: boolean;
+    [ChainId.ARBITRUM]: boolean;
+    [ChainId.CELO]: boolean;
+    [ChainId.OKXCHAIN]: boolean;
+    [ChainId.VELAS]: boolean;
+    [ChainId.AURORA]: boolean;
+    [ChainId.CRONOS]: boolean;
+    [ChainId.FUSE]: boolean;
+    [ChainId.MOONRIVER]: boolean;
+    [ChainId.MOONBEAM]: boolean;
+    [ChainId.OP]: boolean;
+    [ChainId.EVMOS_TESTNET]: boolean;
+    [ChainId.EVMOS_MAINNET]: boolean;
+  };
 }
+
+const useSubgraphInitialState = {
+  [ChainId.FUJI]: false,
+  [ChainId.AVALANCHE]: false,
+  [ChainId.WAGMI]: false,
+  [ChainId.COSTON]: false,
+  [ChainId.SONGBIRD]: false,
+  [ChainId.FLARE_MAINNET]: false,
+  [ChainId.HEDERA_TESTNET]: true,
+  [ChainId.HEDERA_MAINNET]: true,
+  [ChainId.NEAR_MAINNET]: false,
+  [ChainId.NEAR_TESTNET]: false,
+  [ChainId.COSTON2]: false,
+  [ChainId.ETHEREUM]: false,
+  [ChainId.POLYGON]: false,
+  [ChainId.FANTOM]: false,
+  [ChainId.XDAI]: false,
+  [ChainId.BSC]: false,
+  [ChainId.ARBITRUM]: false,
+  [ChainId.CELO]: false,
+  [ChainId.OKXCHAIN]: false,
+  [ChainId.VELAS]: false,
+  [ChainId.AURORA]: false,
+  [ChainId.CRONOS]: false,
+  [ChainId.FUSE]: false,
+  [ChainId.MOONRIVER]: false,
+  [ChainId.MOONBEAM]: false,
+  [ChainId.OP]: false,
+  [ChainId.EVMOS_TESTNET]: false,
+  [ChainId.EVMOS_MAINNET]: false,
+};
 
 const blockNumbersAtom = atom<ApplicationState['blockNumbers']>({});
 const popupListAtom = atom<ApplicationState['popupList']>([]);
 const openModalAtom = atom<ApplicationState['openModal']>(null);
 const selectedPoolIdAtom = atom<ApplicationState['selectedPoolId']>(undefined);
 const isAvailableHashpackAtom = atom<ApplicationState['isAvailableHashpack']>(false);
+const useSubgraphAtom = atom<ApplicationState['useSubgraph']>(useSubgraphInitialState);
 
 export function useApplicationState() {
   const [blockNumbers, setBlockNumbers] = useAtom(blockNumbersAtom);
@@ -47,6 +111,8 @@ export function useApplicationState() {
   const [openModal, setOpenModal] = useAtom(openModalAtom);
   const [selectedPoolId, setSelectedPooId] = useAtom(selectedPoolIdAtom);
   const [isAvailableHashpack, setAvailableHashpack] = useAtom(isAvailableHashpackAtom);
+
+  const [useSubgraph, setUseSubgraph] = useAtom(useSubgraphAtom);
 
   const updateBlockNumber = useCallback(
     ({ chainId, blockNumber }: { chainId: number; blockNumber: number }) => {
@@ -101,11 +167,13 @@ export function useApplicationState() {
     selectedPoolId,
     openModal,
     popupList,
+    useSubgraph,
     updateBlockNumber,
     setAvailableHashpack,
     setSelectedPooId,
     setOpenModal,
     addPopup,
     removePopup,
+    setUseSubgraph,
   };
 }

--- a/src/state/papplication/hooks.ts
+++ b/src/state/papplication/hooks.ts
@@ -69,3 +69,9 @@ export function useUpdateSelectedPoolId(): (poolId: string | undefined) => void 
   const { setSelectedPooId } = useApplicationState();
   return useCallback((poolId: string | undefined) => setSelectedPooId(poolId), [setSelectedPooId]);
 }
+
+export function useShouldUseSubgraph(): boolean {
+  const chainId = useChainId();
+  const { useSubgraph } = useApplicationState();
+  return useSubgraph?.[chainId];
+}

--- a/src/state/ppangoChef/hooks/evm.ts
+++ b/src/state/ppangoChef/hooks/evm.ts
@@ -9,7 +9,7 @@ import ERC20_INTERFACE from 'src/constants/abis/erc20';
 import { PANGOLIN_PAIR_INTERFACE } from 'src/constants/abis/pangolinPair';
 import { REWARDER_VIA_MULTIPLIER_INTERFACE } from 'src/constants/abis/rewarderViaMultiplier';
 import { PNG, USDC } from 'src/constants/tokens';
-import { PairState, usePair, usePairs } from 'src/data/Reserves';
+import { PairState, usePair, usePairsContract } from 'src/data/Reserves';
 import { useChainId, usePangolinWeb3, useRefetchMinichefSubgraph } from 'src/hooks';
 import { useLastBlockTimestampHook } from 'src/hooks/block';
 import { useTokensContract } from 'src/hooks/tokens/evm';
@@ -157,7 +157,7 @@ export function usePangoChefInfos() {
   }, [tokens0, tokens1]);
 
   // get the pairs for each pool
-  const pairs = usePairs(tokensPairs);
+  const pairs = usePairsContract(tokensPairs);
 
   const pairAddresses = useMemo(() => {
     return pairs.map(([, pair]) => pair?.liquidityToken?.address);

--- a/src/state/ppangoChef/hooks/evm.ts
+++ b/src/state/ppangoChef/hooks/evm.ts
@@ -12,7 +12,7 @@ import { PNG, USDC } from 'src/constants/tokens';
 import { PairState, usePair, usePairs } from 'src/data/Reserves';
 import { useChainId, usePangolinWeb3, useRefetchMinichefSubgraph } from 'src/hooks';
 import { useLastBlockTimestampHook } from 'src/hooks/block';
-import { useTokens } from 'src/hooks/tokens/evm';
+import { useTokensContract } from 'src/hooks/tokens/evm';
 import { usePangoChefContract, useStakingContract } from 'src/hooks/useContract';
 import { usePairsCurrencyPrice } from 'src/hooks/useCurrencyPrice';
 import { useCoinGeckoCurrencyPrice } from 'src/state/pcoingecko/hooks';
@@ -139,8 +139,8 @@ export function usePangoChefInfos() {
     return tokens1State.map((result) => (result?.result && result?.result?.length > 0 ? result?.result[0] : null));
   }, [tokens1State]);
 
-  const tokens0 = useTokens(tokens0Adrr);
-  const tokens1 = useTokens(tokens1Adrr);
+  const tokens0 = useTokensContract(tokens0Adrr);
+  const tokens1 = useTokensContract(tokens1Adrr);
 
   const tokensPairs = useMemo(() => {
     if (tokens0 && tokens1 && tokens0?.length === tokens1?.length) {

--- a/src/state/ppangoChef/hooks/hedera.ts
+++ b/src/state/ppangoChef/hooks/hedera.ts
@@ -11,7 +11,7 @@ import ERC20_INTERFACE from 'src/constants/abis/erc20';
 import { PANGOLIN_PAIR_INTERFACE } from 'src/constants/abis/pangolinPair';
 import { REWARDER_VIA_MULTIPLIER_INTERFACE } from 'src/constants/abis/rewarderViaMultiplier';
 import { PNG, USDC } from 'src/constants/tokens';
-import { PairState, usePair, usePairs } from 'src/data/Reserves';
+import { PairState, usePair, usePairsContract } from 'src/data/Reserves';
 import { useChainId, usePangolinWeb3 } from 'src/hooks';
 import { useLastBlockTimestampHook } from 'src/hooks/block';
 import { useTokensContract } from 'src/hooks/tokens/evm';
@@ -168,7 +168,7 @@ export function useHederaPangoChefInfos() {
   }, [tokens0, tokens1]);
 
   // get the pairs for each pool
-  const pairs = usePairs(tokensPairs);
+  const pairs = usePairsContract(tokensPairs);
 
   const pairAddresses = useMemo(() => {
     return pairs.map(([, pair]) => pair?.liquidityToken?.address);

--- a/src/state/ppangoChef/hooks/hedera.ts
+++ b/src/state/ppangoChef/hooks/hedera.ts
@@ -23,6 +23,7 @@ import { useTransactionAdder } from 'src/state/ptransactions/hooks';
 import { useHederaPGLTokenAddresses, useHederaPairContractEVMAddresses } from 'src/state/pwallet/hooks/hedera';
 import { decimalToFraction } from 'src/utils';
 import { hederaFn } from 'src/utils/hedera';
+import { useShouldUseSubgraph } from '../../papplication/hooks';
 import {
   useMultipleContractSingleData,
   useSingleCallResult,
@@ -814,6 +815,18 @@ export function useGetPangoChefInfosViaSubgraph() {
     blockTime,
   ]);
 }
+
+/**
+ * its wrapper hook to check which hook need to use based on subgraph on off
+ * @returns
+ */
+
+export const useHederaPangochef = () => {
+  const shouldUseSubgraph = useShouldUseSubgraph();
+  const useHook = shouldUseSubgraph ? useGetPangoChefInfosViaSubgraph : useHederaPangoChefInfos;
+  const res = useHook();
+  return res;
+};
 
 /**
  * this hook is useful to check whether user has created pangochef storage contract or not

--- a/src/state/ppangoChef/hooks/hedera.ts
+++ b/src/state/ppangoChef/hooks/hedera.ts
@@ -14,7 +14,7 @@ import { PNG, USDC } from 'src/constants/tokens';
 import { PairState, usePair, usePairs } from 'src/data/Reserves';
 import { useChainId, usePangolinWeb3 } from 'src/hooks';
 import { useLastBlockTimestampHook } from 'src/hooks/block';
-import { useTokens } from 'src/hooks/tokens/evm';
+import { useTokensContract } from 'src/hooks/tokens/evm';
 import { usePangoChefContract } from 'src/hooks/useContract';
 import { usePairsCurrencyPrice } from 'src/hooks/useCurrencyPrice';
 import { useCoinGeckoCurrencyPrice } from 'src/state/pcoingecko/hooks';
@@ -150,8 +150,8 @@ export function useHederaPangoChefInfos() {
     return tokens1State.map((result) => (result?.result && result?.result?.length > 0 ? result?.result[0] : null));
   }, [tokens1State]);
 
-  const tokens0 = useTokens(tokens0Adrr);
-  const tokens1 = useTokens(tokens1Adrr);
+  const tokens0 = useTokensContract(tokens0Adrr);
+  const tokens1 = useTokensContract(tokens1Adrr);
 
   const tokensPairs = useMemo(() => {
     if (tokens0 && tokens1 && tokens0?.length === tokens1?.length) {
@@ -821,12 +821,12 @@ export function useGetPangoChefInfosViaSubgraph() {
  * @returns
  */
 
-export const useHederaPangochef = () => {
+export function useHederaPangochef() {
   const shouldUseSubgraph = useShouldUseSubgraph();
   const useHook = shouldUseSubgraph ? useGetPangoChefInfosViaSubgraph : useHederaPangoChefInfos;
   const res = useHook();
   return res;
-};
+}
 
 /**
  * this hook is useful to check whether user has created pangochef storage contract or not

--- a/src/state/ppangoChef/hooks/index.ts
+++ b/src/state/ppangoChef/hooks/index.ts
@@ -14,13 +14,15 @@ import {
   useHederaPangoChefCompoundCallback,
   useHederaPangoChefStakeCallback,
   useHederaPangoChefWithdrawCallback,
+  useHederaPangochef,
 } from './hedera';
 
 export type UsePangoChefInfosHookType = {
   [chainId in ChainId]:
     | typeof usePangoChefInfos
     | typeof useGetPangoChefInfosViaSubgraph
-    | typeof useDummyPangoChefInfos;
+    | typeof useDummyPangoChefInfos
+    | typeof useHederaPangochef;
 };
 
 export const usePangoChefInfosHook: UsePangoChefInfosHookType = {
@@ -30,8 +32,8 @@ export const usePangoChefInfosHook: UsePangoChefInfosHookType = {
   [ChainId.COSTON]: usePangoChefInfos,
   [ChainId.SONGBIRD]: usePangoChefInfos,
   [ChainId.FLARE_MAINNET]: usePangoChefInfos,
-  [ChainId.HEDERA_TESTNET]: useGetPangoChefInfosViaSubgraph,
-  [ChainId.HEDERA_MAINNET]: useGetPangoChefInfosViaSubgraph,
+  [ChainId.HEDERA_TESTNET]: useHederaPangochef,
+  [ChainId.HEDERA_MAINNET]: useHederaPangochef,
   [ChainId.NEAR_MAINNET]: useDummyPangoChefInfos,
   [ChainId.NEAR_TESTNET]: useDummyPangoChefInfos,
   [ChainId.COSTON2]: usePangoChefInfos,

--- a/src/state/pstake/hooks/evm.ts
+++ b/src/state/pstake/hooks/evm.ts
@@ -14,7 +14,7 @@ import { MINICHEF_ADDRESS } from 'src/constants/address';
 import { DAIe, PNG, USDC, USDCe, USDTe } from 'src/constants/tokens';
 import { PairState, usePair, usePairs } from 'src/data/Reserves';
 import { useChainId, usePangolinWeb3 } from 'src/hooks';
-import { useTokens } from 'src/hooks/tokens/evm';
+import { useTokensContract } from 'src/hooks/tokens/evm';
 import { useUSDCPrice } from 'src/hooks/useUSDCPrice/evm';
 import { useMiniChefContract } from '../../../hooks/useContract';
 import {
@@ -91,8 +91,8 @@ export const useMinichefStakingInfos = (version = 2, pairToFilterBy?: Pair | nul
     return _tokens1Call.map((result) => (result.result && result.result.length > 0 ? result.result[0] : null));
   }, [_tokens1Call]);
 
-  const tokens0 = useTokens(tokens0Adrr);
-  const tokens1 = useTokens(tokens1Adrr);
+  const tokens0 = useTokensContract(tokens0Adrr);
+  const tokens1 = useTokensContract(tokens1Adrr);
 
   const info = useMemo(() => {
     const filterPair = (item: DoubleSideStaking) => {

--- a/src/state/pstake/hooks/evm.ts
+++ b/src/state/pstake/hooks/evm.ts
@@ -12,7 +12,7 @@ import { PANGOLIN_PAIR_INTERFACE } from 'src/constants/abis/pangolinPair';
 import { REWARDER_VIA_MULTIPLIER_INTERFACE } from 'src/constants/abis/rewarderViaMultiplier';
 import { MINICHEF_ADDRESS } from 'src/constants/address';
 import { DAIe, PNG, USDC, USDCe, USDTe } from 'src/constants/tokens';
-import { PairState, usePair, usePairs } from 'src/data/Reserves';
+import { PairState, usePair, usePairsContract } from 'src/data/Reserves';
 import { useChainId, usePangolinWeb3 } from 'src/hooks';
 import { useTokensContract } from 'src/hooks/tokens/evm';
 import { useUSDCPrice } from 'src/hooks/useUSDCPrice/evm';
@@ -123,7 +123,7 @@ export const useMinichefStakingInfos = (version = 2, pairToFilterBy?: Pair | nul
   }, [chainId, minichefContract, tokens0, tokens1, pairToFilterBy, version]);
 
   const _tokens = useMemo(() => (info ? info.map(({ tokens }) => tokens) : []), [info]);
-  const pairs = usePairs(_tokens);
+  const pairs = usePairsContract(_tokens);
   // @dev: If no farms load, you likely loaded an incorrect config from doubleSideConfig.js
   // Enable this and look for an invalid pair
 

--- a/src/state/pwallet/hooks/evm.ts
+++ b/src/state/pwallet/hooks/evm.ts
@@ -6,7 +6,7 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ERC20_INTERFACE from 'src/constants/abis/erc20';
 import { ROUTER_ADDRESS } from 'src/constants/address';
-import { usePairs } from 'src/data/Reserves';
+import { usePairsContract } from 'src/data/Reserves';
 import { useChainId, useLibrary, usePangolinWeb3, useRefetchMinichefSubgraph } from 'src/hooks';
 import { ApprovalState } from 'src/hooks/useApproveCallback/constant';
 import { useMulticallContract, usePairContract } from 'src/hooks/useContract';
@@ -471,7 +471,7 @@ export function useGetUserLP() {
     [liquidityTokensWithBalances],
   );
 
-  const v2Pairs = usePairs(lpTokensWithBalances);
+  const v2Pairs = usePairsContract(lpTokensWithBalances);
 
   const v2IsLoading =
     fetchingV2PairBalances ||
@@ -488,7 +488,7 @@ export function useGetUserLP() {
     [tokenPairsWithLiquidityTokens],
   );
 
-  const v2AllPairs = usePairs(pairWithLpTokens);
+  const v2AllPairs = usePairsContract(pairWithLpTokens);
 
   const allV2AllPairsWithLiquidity = useMemo(
     () => v2AllPairs.map(([, pair]) => pair).filter((_v2AllPairs): _v2AllPairs is Pair => Boolean(_v2AllPairs)),

--- a/src/state/pwallet/hooks/hedera.ts
+++ b/src/state/pwallet/hooks/hedera.ts
@@ -4,7 +4,7 @@ import { CAVAX, ChainId, Currency, JSBI, Pair, Token, TokenAmount, WAVAX } from 
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueries, useQuery } from 'react-query';
-import { usePair, usePairs } from 'src/data/Reserves';
+import { usePair, usePairsContract } from 'src/data/Reserves';
 import { useChainId, useLibrary, usePangolinWeb3 } from 'src/hooks';
 import { useGetAllHederaAssociatedTokens, useHederaTokenAssociated } from 'src/hooks/tokens/hedera';
 import { useBlockNumber } from 'src/state/papplication/hooks';
@@ -386,7 +386,7 @@ export function useGetHederaUserLP() {
     [pglTokenAddresses, allTokensAddress, pairTokens],
   );
 
-  const allPairs = usePairs(filterPairTokens);
+  const allPairs = usePairsContract(filterPairTokens);
 
   const checkedAllPairs = useMemo(
     () => allPairs.map(([, pair]) => pair).filter((v2Pair): v2Pair is Pair => Boolean(v2Pair)),


### PR DESCRIPTION
Problem: When Subgraph stop we manually change Subgraph hooks to Contract Hooks
Solution: Now these hooks works based on "flag" set in atom so if flag changes, hooks logic will change accordingly.