### PR TITLE
fix: ui bugs related to refetch subgraph queries, extra tokens weekly income on hedera  and page crashes

### DIFF
--- a/src/apollo/pairs.ts
+++ b/src/apollo/pairs.ts
@@ -73,20 +73,26 @@ export const useSubgraphPairs = (pairAddresses: (string | undefined)[]) => {
   const gqlClient = useSubgraphClient(SubgraphEnum.Exchange);
   const validateAddress = validateAddressMapping[chainId];
   // get pairs from subgraph
-  return useQuery<SubgraphPair[] | null>(['get-subgraph-pairs', chainId, ...pairsToFind], async () => {
-    if (!gqlClient) {
-      return null;
-    }
-    const data = await gqlClient.request(GET_PAIRS, { pairAddresses: pairsToFind });
+  return useQuery<SubgraphPair[] | null>(
+    ['get-subgraph-pairs', chainId, ...pairsToFind],
+    async () => {
+      if (!gqlClient) {
+        return null;
+      }
+      const data = await gqlClient.request(GET_PAIRS, { pairAddresses: pairsToFind });
 
-    return (
-      (data?.pairs as SubgraphPair[])
-        // convert addresses to checksum address
-        ?.map((item) => ({ ...item, id: validateAddress(item.id) as string }))
-        // only keep pairs that has id as string
-        // because validateAddress returns string if valid address
-        // and return false if invalid address, so we want to remove those invalid address tokens
-        ?.filter((item) => typeof item.id === 'string')
-    );
-  });
+      return (
+        (data?.pairs as SubgraphPair[])
+          // convert addresses to checksum address
+          ?.map((item) => ({ ...item, id: validateAddress(item.id) as string }))
+          // only keep pairs that has id as string
+          // because validateAddress returns string if valid address
+          // and return false if invalid address, so we want to remove those invalid address tokens
+          ?.filter((item) => typeof item.id === 'string')
+      );
+    },
+    {
+      refetchInterval: 2 * 60 * 1000,
+    },
+  );
 };

--- a/src/components/Pools/ClaimReward/index.tsx
+++ b/src/components/Pools/ClaimReward/index.tsx
@@ -7,7 +7,7 @@ import { PNG } from 'src/constants/tokens';
 import { useChainId, usePangolinWeb3 } from 'src/hooks';
 import { MixPanelEvents, useMixpanel } from 'src/hooks/mixpanel';
 import { useStakingContract } from 'src/hooks/useContract';
-import { useMinichefPendingRewards, useMinichefPools } from 'src/state/pstake/hooks/common';
+import { useExtraPendingRewards, useMinichefPools } from 'src/state/pstake/hooks/common';
 import { DoubleSideStakingInfo, MinichefStakingInfo } from 'src/state/pstake/types';
 import { useTransactionAdder } from 'src/state/ptransactions/hooks';
 import { waitForTransaction } from 'src/utils';
@@ -32,7 +32,7 @@ const ClaimReward = ({ stakingInfo, version, onClose }: ClaimProps) => {
   const poolMap = useMinichefPools();
   const stakingContract = useStakingContract(stakingInfo.stakingRewardAddress);
 
-  const { rewardTokensAmount } = useMinichefPendingRewards(stakingInfo);
+  const { rewardTokensAmount } = useExtraPendingRewards(stakingInfo);
 
   const isSuperFarm = (rewardTokensAmount || [])?.length > 0;
 

--- a/src/components/Pools/DetailModal/EarnedDetail/index.tsx
+++ b/src/components/Pools/DetailModal/EarnedDetail/index.tsx
@@ -5,7 +5,7 @@ import { Box, Button, Stat, Text } from 'src/components';
 import { BIG_INT_ZERO } from 'src/constants';
 import { PNG } from 'src/constants/tokens';
 import { useChainId } from 'src/hooks';
-import { useMinichefPendingRewards } from 'src/state/pstake/hooks/common';
+import { useExtraPendingRewards } from 'src/state/pstake/hooks/common';
 import { DoubleSideStakingInfo } from 'src/state/pstake/types';
 import ClaimDrawer from '../../ClaimDrawer';
 import RemoveDrawer from '../../RemoveDrawer';
@@ -23,7 +23,7 @@ const EarnedDetail = ({ stakingInfo, version }: EarnDetailProps) => {
   const [isClaimDrawerVisible, setShowClaimDrawer] = useState(false);
   const [isRemoveDrawerVisible, setShowRemoveDrawer] = useState(false);
 
-  const { rewardTokensAmount, rewardTokensMultiplier } = useMinichefPendingRewards(stakingInfo);
+  const { rewardTokensAmount, rewardTokensMultiplier } = useExtraPendingRewards(stakingInfo);
 
   const isSuperFarm = (rewardTokensAmount || [])?.length > 0;
 

--- a/src/components/Pools/DetailModal/Header/index.tsx
+++ b/src/components/Pools/DetailModal/Header/index.tsx
@@ -44,7 +44,7 @@ const Header: React.FC<Props> = ({ stakingInfo, onClose }) => {
   const userRewardRate =
     cheftType === ChefType.PANGO_CHEF ? (stakingInfo as PangoChefInfo)?.userRewardRate : BigNumber.from(0);
 
-  const poolBalance = stakingInfo.totalStakedAmount;
+  const poolBalance = stakingInfo?.totalStakedAmount;
   const poolRewardRate =
     cheftType === ChefType.PANGO_CHEF ? (stakingInfo as PangoChefInfo)?.poolRewardRate : BigNumber.from(0);
 

--- a/src/components/Pools/PangoChef/EarnDetail/index.tsx
+++ b/src/components/Pools/PangoChef/EarnDetail/index.tsx
@@ -8,7 +8,7 @@ import { PNG } from 'src/constants/tokens';
 import { useChainId } from 'src/hooks';
 import { useGetLockingPoolsForPoolIdHook } from 'src/state/ppangoChef/hooks';
 import { PangoChefInfo } from 'src/state/ppangoChef/types';
-import { useMinichefPendingRewards } from 'src/state/pstake/hooks/common';
+import { useExtraPendingRewards } from 'src/state/pstake/hooks/common';
 import { unwrappedToken } from 'src/utils/wrappedCurrency';
 import RemoveDrawer from '../../RemoveDrawer';
 import ClaimRewardV3 from '../ClaimReward';
@@ -28,7 +28,7 @@ const EarnedDetailV3 = ({ stakingInfo, version }: EarnDetailProps) => {
   const [isCompoundDrawerVisible, setShowCompoundDrawer] = useState(false);
   const [isRemoveDrawerVisible, setShowRemoveDrawer] = useState(false);
 
-  const { rewardTokensAmount, rewardTokensMultiplier } = useMinichefPendingRewards(stakingInfo);
+  const { rewardTokensAmount, rewardTokensMultiplier } = useExtraPendingRewards(stakingInfo);
 
   const useGetLockingPoolsForPoolId = useGetLockingPoolsForPoolIdHook[chainId];
 
@@ -85,7 +85,7 @@ const EarnedDetailV3 = ({ stakingInfo, version }: EarnDetailProps) => {
           {t('dashboardPage.earned')}
         </Text>
 
-        {/* show unstak button */}
+        {/* show unstake button */}
         <Button
           variant="primary"
           width="100px"
@@ -129,7 +129,11 @@ const EarnedDetailV3 = ({ stakingInfo, version }: EarnDetailProps) => {
                 reward?.token,
                 tokenMultiplier,
               ) as TokenAmount;
-
+              console.log({
+                tokenMultiplier,
+                extraTokenWeeklyRewardRate,
+                rewardRate: extraTokenWeeklyRewardRate.toFixed(8),
+              });
               return (
                 <InnerWrapper key={index}>
                   <Box>

--- a/src/components/Pools/PangoChef/EarnDetail/index.tsx
+++ b/src/components/Pools/PangoChef/EarnDetail/index.tsx
@@ -129,11 +129,7 @@ const EarnedDetailV3 = ({ stakingInfo, version }: EarnDetailProps) => {
                 reward?.token,
                 tokenMultiplier,
               ) as TokenAmount;
-              console.log({
-                tokenMultiplier,
-                extraTokenWeeklyRewardRate,
-                rewardRate: extraTokenWeeklyRewardRate.toFixed(8),
-              });
+
               return (
                 <InnerWrapper key={index}>
                   <Box>

--- a/src/components/Pools/PangoChef/Stake/index.tsx
+++ b/src/components/Pools/PangoChef/Stake/index.tsx
@@ -17,7 +17,7 @@ import useTransactionDeadline from 'src/hooks/useTransactionDeadline';
 import { usePangoChefStakeCallbackHook } from 'src/state/ppangoChef/hooks';
 import { useHederaPangochefContractCreateCallback } from 'src/state/ppangoChef/hooks/hedera';
 import { PangoChefInfo } from 'src/state/ppangoChef/types';
-import { useDerivedStakeInfo, useGetPoolDollerWorth, useMinichefPendingRewards } from 'src/state/pstake/hooks/common';
+import { useDerivedStakeInfo, useExtraPendingRewards, useGetPoolDollerWorth } from 'src/state/pstake/hooks/common';
 import { SpaceType } from 'src/state/pstake/types';
 import { usePairBalanceHook } from 'src/state/pwallet/hooks';
 import { unwrappedToken, wrappedCurrencyAmount } from 'src/utils/wrappedCurrency';
@@ -76,7 +76,7 @@ const Stake = ({ onComplete, type, stakingInfo, combinedApr }: StakeProps) => {
     );
   }
 
-  const { rewardTokensAmount, rewardTokensMultiplier } = useMinichefPendingRewards(stakingInfo);
+  const { rewardTokensAmount, rewardTokensMultiplier } = useExtraPendingRewards(stakingInfo);
 
   const isSuperFarm = (rewardTokensAmount || [])?.length > 0;
 

--- a/src/components/Pools/RemoveFarm/index.tsx
+++ b/src/components/Pools/RemoveFarm/index.tsx
@@ -8,7 +8,7 @@ import { useChainId, usePangolinWeb3 } from 'src/hooks';
 import { MixPanelEvents, useMixpanel } from 'src/hooks/mixpanel';
 import { useGetHederaTokenNotAssociated, useHederaTokenAssociated } from 'src/hooks/tokens/hedera';
 import { usePangoChefWithdrawCallbackHook } from 'src/state/ppangoChef/hooks';
-import { useGetRewardTokens, useMinichefPendingRewards } from 'src/state/pstake/hooks/common';
+import { useExtraPendingRewards, useGetRewardTokens } from 'src/state/pstake/hooks/common';
 import { DoubleSideStakingInfo, MinichefStakingInfo } from 'src/state/pstake/types';
 import { useHederaPGLToken } from 'src/state/pwallet/hooks/hedera';
 import { hederaFn } from 'src/utils/hedera';
@@ -43,7 +43,7 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoading, onComplete, redi
 
   const chefType = CHAINS[chainId].contracts?.mini_chef?.type ?? ChefType.MINI_CHEF_V2;
 
-  const { rewardTokensAmount } = useMinichefPendingRewards(stakingInfo);
+  const { rewardTokensAmount } = useExtraPendingRewards(stakingInfo);
   const rewardTokens = useGetRewardTokens(stakingInfo);
   const isSuperFarm = (rewardTokensAmount || [])?.length > 0;
 

--- a/src/components/Pools/Stake/index.tsx
+++ b/src/components/Pools/Stake/index.tsx
@@ -27,8 +27,8 @@ import { useGetTransactionSignature } from 'src/hooks/useGetTransactionSignature
 import useTransactionDeadline from 'src/hooks/useTransactionDeadline';
 import {
   useDerivedStakeInfo,
+  useExtraPendingRewards,
   useGetPoolDollerWorth,
-  useMinichefPendingRewards,
   useMinichefPools,
 } from 'src/state/pstake/hooks/common';
 import { DoubleSideStakingInfo, SpaceType } from 'src/state/pstake/types';
@@ -95,7 +95,7 @@ const Stake = ({ version, onComplete, type, stakingInfo, combinedApr }: StakePro
     );
   }
 
-  const { rewardTokensAmount, rewardTokensMultiplier } = useMinichefPendingRewards(stakingInfo);
+  const { rewardTokensAmount, rewardTokensMultiplier } = useExtraPendingRewards(stakingInfo);
 
   const isSuperFarm = (rewardTokensAmount || [])?.length > 0;
 

--- a/src/state/ppangoChef/hooks/evm.ts
+++ b/src/state/ppangoChef/hooks/evm.ts
@@ -341,7 +341,7 @@ export function usePangoChefInfos() {
         );
       };
 
-      const expoent = png.decimals - pair?.liquidityToken.decimals;
+      const exponent = png.decimals - pair?.liquidityToken.decimals;
 
       // poolAPR = poolRewardRate(POOL_ID) * 365 days * 100 * PNG_PRICE / (pools(POOL_ID).valueVariables.balance * STAKING_TOKEN_PRICE)
       const apr =
@@ -353,7 +353,7 @@ export function usePangoChefInfos() {
                 .divide(
                   pairPrice
                     .multiply(pool?.valueVariables?.balance?.toString())
-                    .multiply(JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(expoent))),
+                    .multiply(JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(exponent))),
                 )
                 .toSignificant(2),
             );

--- a/src/state/ppangoChef/hooks/hedera.ts
+++ b/src/state/ppangoChef/hooks/hedera.ts
@@ -718,7 +718,7 @@ export function useGetPangoChefInfosViaSubgraph() {
 
       const pairPriceInEth = totalSupplyInETH.divide(totalSupplyAmount);
 
-      const expoent = png.decimals - lpToken.decimals;
+      const exponent = png.decimals - lpToken.decimals;
 
       // poolAPR = poolRewardRate(POOL_ID) * 365 days * 100 * PNG_PRICE / ((pools(POOL_ID).valueVariables.balance * STAKING_TOKEN_PRICE) * 1e(png.decimals-lptoken.decimals))
       const apr =
@@ -729,7 +729,7 @@ export function useGetPangoChefInfosViaSubgraph() {
                 .multiply(rewardRate.mul(365 * 86400 * 100).toString())
                 .divide(pairPriceInEth?.multiply(_farmTvl))
                 // here apr is in 10^(png.decimals - lpToken.decimals) so we needed to divide by 10^(png.decimals - lpToken.decimals) to keep it in simple form
-                .divide(JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(expoent)))
+                .divide(JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(exponent)))
                 .toSignificant(2),
             );
 

--- a/src/state/pstake/hooks/common.ts
+++ b/src/state/pstake/hooks/common.ts
@@ -232,7 +232,7 @@ export function useGetRewardTokens(stakingInfo: DoubleSideStakingInfo) {
 
   return useMemo(() => {
     const rewardTokens =
-      cheftType === ChefType.MINI_CHEF ? undefined : (stakingInfo as MinichefStakingInfo).rewardTokens;
+      cheftType === ChefType.MINI_CHEF ? undefined : (stakingInfo as MinichefStakingInfo)?.rewardTokens;
 
     if (!rewardTokens && _rewardTokens) {
       // filter only tokens

--- a/src/state/pstake/hooks/common.ts
+++ b/src/state/pstake/hooks/common.ts
@@ -223,7 +223,7 @@ export function useGetRewardTokens(stakingInfo: DoubleSideStakingInfo) {
       return undefined;
     }
 
-    return stakingInfo.rewardTokensAddress;
+    return stakingInfo?.rewardTokensAddress;
   }
 
   const tokensAddresses = getRewardsTokensAddresses();

--- a/src/state/pstake/utils.ts
+++ b/src/state/pstake/utils.ts
@@ -110,13 +110,13 @@ export function getExtraTokensWeeklyRewardRate(
   tokenMultiplier: JSBI | undefined,
 ) {
   const png = PNG[token.chainId];
-  const EXPOENT = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(png.decimals));
+  const EXPONENT = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(png.decimals));
 
   const rewardMultiplier = JSBI.BigInt(tokenMultiplier || 1);
 
   const unadjustedRewardPerWeek = JSBI.multiply(rewardMultiplier, rewardRatePerWeek?.raw);
 
-  const finalReward = JSBI.divide(unadjustedRewardPerWeek, EXPOENT);
+  const finalReward = JSBI.divide(unadjustedRewardPerWeek, EXPONENT);
 
   return new TokenAmount(token, finalReward);
 }

--- a/src/state/pstake/utils.ts
+++ b/src/state/pstake/utils.ts
@@ -109,7 +109,8 @@ export function getExtraTokensWeeklyRewardRate(
   token: Token,
   tokenMultiplier: JSBI | undefined,
 ) {
-  const TEN_EIGHTEEN = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(18));
+  const png = PNG[token.chainId];
+  const TEN_EIGHTEEN = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(png.decimals));
 
   const rewardMultiplier = JSBI.BigInt(tokenMultiplier || 1);
 

--- a/src/state/pstake/utils.ts
+++ b/src/state/pstake/utils.ts
@@ -110,13 +110,13 @@ export function getExtraTokensWeeklyRewardRate(
   tokenMultiplier: JSBI | undefined,
 ) {
   const png = PNG[token.chainId];
-  const TEN_EIGHTEEN = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(png.decimals));
+  const EXPOENT = JSBI.exponentiate(JSBI.BigInt(10), JSBI.BigInt(png.decimals));
 
   const rewardMultiplier = JSBI.BigInt(tokenMultiplier || 1);
 
   const unadjustedRewardPerWeek = JSBI.multiply(rewardMultiplier, rewardRatePerWeek?.raw);
 
-  const finalReward = JSBI.divide(unadjustedRewardPerWeek, TEN_EIGHTEEN);
+  const finalReward = JSBI.divide(unadjustedRewardPerWeek, EXPOENT);
 
   return new TokenAmount(token, finalReward);
 }


### PR DESCRIPTION
## Summary
- Fixed the create pairs by interface not appears, we need to refetch the subgraph query
- Fixed the extra tokens "weekly income" on hedera
- Fixed page crash when change chain and have a farm details open
