### PR TITLE
fix: ui bugs related with load swap fast, reset signature in "onRemove" and fields in remove farm are collapsing

### DIFF
--- a/src/components/Pools/RemoveFarm/index.tsx
+++ b/src/components/Pools/RemoveFarm/index.tsx
@@ -1,4 +1,5 @@
 import { CHAINS, ChefType, Token } from '@pangolindex/sdk';
+import numeral from 'numeral';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Box, Button, Loader, Stat, Text, TransactionCompleted } from 'src/components';
@@ -83,10 +84,12 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoading, onComplete, redi
     hederaAssociated: isHederaTokenAssociated,
   } = useHederaTokenAssociated(notAssociateTokens?.[0]?.address, notAssociateTokens?.[0]?.symbol);
 
+  const stakedAmount = stakingInfo?.stakedAmount;
+
   const { callback: withdrawCallback, error: withdrawCallbackError } = useWithdrawCallback({
     version,
     poolId: chefType === ChefType.MINI_CHEF ? undefined : (stakingInfo as MinichefStakingInfo)?.pid,
-    stakedAmount: stakingInfo?.stakedAmount,
+    stakedAmount: stakedAmount,
     stakingRewardAddress: stakingInfo?.stakingRewardAddress,
   });
 
@@ -103,7 +106,7 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoading, onComplete, redi
   }
 
   async function onWithdraw() {
-    if (stakingInfo?.stakedAmount && withdrawCallback) {
+    if (stakedAmount && withdrawCallback) {
       setAttempting(true);
 
       try {
@@ -181,12 +184,17 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoading, onComplete, redi
                     <StatWrapper>
                       <Stat
                         title={t('earn.depositedToken', { symbol: 'PGL' })}
-                        stat={stakingInfo?.stakedAmount?.toSignificant(4)}
+                        stat={numeral(
+                          stakedAmount?.toFixed(
+                            stakedAmount?.greaterThan('0') && stakedAmount?.token?.decimals > 1 ? 2 : undefined,
+                          ),
+                        ).format('0.00a')}
                         titlePosition="top"
                         titleFontSize={12}
                         statFontSize={[20, 18]}
                         titleColor="text1"
                         statAlign="center"
+                        toolTipText={stakedAmount?.toExact()}
                       />
                     </StatWrapper>
                   )}
@@ -194,12 +202,17 @@ const RemoveFarm = ({ stakingInfo, version, onClose, onLoading, onComplete, redi
                     <StatWrapper>
                       <Stat
                         title={t('earn.unclaimedReward', { symbol: png.symbol })}
-                        stat={earnedAmount?.toSignificant(4)}
+                        stat={numeral(
+                          earnedAmount?.toFixed(
+                            earnedAmount?.greaterThan('0') && earnedAmount?.token?.decimals > 1 ? 2 : undefined,
+                          ),
+                        ).format('0.00a')}
                         titlePosition="top"
                         titleFontSize={12}
                         statFontSize={[20, 18]}
                         titleColor="text1"
                         statAlign="center"
+                        toolTipText={earnedAmount?.toExact()}
                       />
                     </StatWrapper>
                   )}

--- a/src/components/Pools/RemoveLiquidity/index.tsx
+++ b/src/components/Pools/RemoveLiquidity/index.tsx
@@ -165,6 +165,7 @@ const RemoveLiquidity = ({ currencyA, currencyB, onLoading, onComplete }: Remove
       console.error(_err);
     } finally {
       setAttempting(false);
+      setSignatureData(null);
     }
   }
 

--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -18,7 +18,7 @@ export type UsePairsHookType = {
 
 export const usePairsHook: UsePairsHookType = {
   [ChainId.FUJI]: usePairsContract,
-  [ChainId.AVALANCHE]: usePairsContract,
+  [ChainId.AVALANCHE]: usePairs,
   [ChainId.WAGMI]: usePairsContract,
   [ChainId.COSTON]: usePairsContract,
   [ChainId.SONGBIRD]: usePairsContract,

--- a/src/state/papplication/atom.ts
+++ b/src/state/papplication/atom.ts
@@ -69,7 +69,7 @@ export interface ApplicationState {
 
 const useSubgraphInitialState = {
   [ChainId.FUJI]: false,
-  [ChainId.AVALANCHE]: false,
+  [ChainId.AVALANCHE]: true,
   [ChainId.WAGMI]: false,
   [ChainId.COSTON]: false,
   [ChainId.SONGBIRD]: false,


### PR DESCRIPTION
## Summary

- Changed avalanche to use pairs from subgraph, to make the swap more fast
- Reset signature in finally on "onRemove" function
- Fixed the fields in "Remove Farm" widget are collapsing


