### PR TITLE
fix: bugs related with refetch subgraphs, second token not enable in serach token drawer

### DIFF
--- a/src/components/Pools/AddLiquidityModal/index.tsx
+++ b/src/components/Pools/AddLiquidityModal/index.tsx
@@ -140,8 +140,8 @@ const AddLiquidityModal = ({ isOpen, onClose }: AddLiquidityModalProps) => {
           />
           <SelectTokenDrawer
             isOpen={showSearch}
-            selectedCurrency={currency0}
-            otherSelectedCurrency={currency1}
+            selectedCurrency={activeField === Fields.TOKEN0 ? currency0 : currency1}
+            otherSelectedCurrency={activeField === Fields.TOKEN0 ? currency1 : currency0}
             onCurrencySelect={handleCurrencySelect}
             onClose={handleClose}
           />

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -163,9 +163,10 @@ export function useLibrary(): { library: any; provider: any } {
 
 export const useRefetchMinichefSubgraph = () => {
   const { account } = usePangolinWeb3();
+  const chainId = useChainId();
   const queryClient = useQueryClient();
 
-  return async () => await queryClient.refetchQueries(['get-minichef-farms-v2', account]);
+  return async () => await queryClient.refetchQueries(['get-minichef-farms-v2', account, chainId]);
 };
 
 export function useRefetchPangoChefSubgraph() {

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -167,3 +167,11 @@ export const useRefetchMinichefSubgraph = () => {
 
   return async () => await queryClient.refetchQueries(['get-minichef-farms-v2', account]);
 };
+
+export function useRefetchPangoChefSubgraph() {
+  const { account } = usePangolinWeb3();
+  const chainId = useChainId();
+  const queryClient = useQueryClient();
+
+  return async () => await queryClient.refetchQueries(['get-pangochef-subgraph-farms', chainId, account]);
+}

--- a/src/state/ppangoChef/hooks/evm.ts
+++ b/src/state/ppangoChef/hooks/evm.ts
@@ -10,7 +10,7 @@ import { PANGOLIN_PAIR_INTERFACE } from 'src/constants/abis/pangolinPair';
 import { REWARDER_VIA_MULTIPLIER_INTERFACE } from 'src/constants/abis/rewarderViaMultiplier';
 import { PNG, USDC } from 'src/constants/tokens';
 import { PairState, usePair, usePairsContract } from 'src/data/Reserves';
-import { useChainId, usePangolinWeb3, useRefetchMinichefSubgraph } from 'src/hooks';
+import { useChainId, usePangolinWeb3, useRefetchMinichefSubgraph, useRefetchPangoChefSubgraph } from 'src/hooks';
 import { useLastBlockTimestampHook } from 'src/hooks/block';
 import { useTokensContract } from 'src/hooks/tokens/evm';
 import { usePangoChefContract, useStakingContract } from 'src/hooks/useContract';
@@ -453,6 +453,7 @@ export function useEVMPangoChefStakeCallback(
   const chainId = useChainId();
   const { t } = useTranslation();
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
 
   const pangoChefContract = usePangoChefContract();
   return useMemo(() => {
@@ -467,6 +468,8 @@ export function useEVMPangoChefStakeCallback(
             addTransaction(response, {
               summary: t('earn.depositLiquidity'),
             });
+
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 
@@ -505,6 +508,7 @@ export function useEVMPangoChefClaimRewardCallback(
   const png = PNG[chainId];
 
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
 
   const pangoChefContract = usePangoChefContract();
   return useMemo(() => {
@@ -520,6 +524,8 @@ export function useEVMPangoChefClaimRewardCallback(
             addTransaction(response, {
               summary: t('earn.claimAccumulated', { symbol: png.symbol }),
             });
+
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 
@@ -563,6 +569,7 @@ export function useEVMPangoChefWithdrawCallback(withdrawData: WithdrawData): {
   const pangoChefContract = usePangoChefContract();
 
   const refetchMinichefSubgraph = useRefetchMinichefSubgraph();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
   const contract = version && version <= 2 ? stakingContract : pangoChefContract;
 
   return useMemo(() => {
@@ -588,6 +595,7 @@ export function useEVMPangoChefWithdrawCallback(withdrawData: WithdrawData): {
               summary: t('earn.withdrawDepositedLiquidity'),
             });
             await refetchMinichefSubgraph();
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 
@@ -623,6 +631,7 @@ export function useEVMPangoChefCompoundCallback(compoundData: PangoChefCompoundD
   const chainId = useChainId();
   const { t } = useTranslation();
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
 
   const { poolId, isPNGPool, amountToAdd } = compoundData;
 
@@ -665,6 +674,7 @@ export function useEVMPangoChefCompoundCallback(compoundData: PangoChefCompoundD
               summary: t('pangoChef.compoundTransactionSummary'),
             });
 
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 

--- a/src/state/ppangoChef/hooks/hedera.ts
+++ b/src/state/ppangoChef/hooks/hedera.ts
@@ -12,7 +12,7 @@ import { PANGOLIN_PAIR_INTERFACE } from 'src/constants/abis/pangolinPair';
 import { REWARDER_VIA_MULTIPLIER_INTERFACE } from 'src/constants/abis/rewarderViaMultiplier';
 import { PNG, USDC } from 'src/constants/tokens';
 import { PairState, usePair, usePairsContract } from 'src/data/Reserves';
-import { useChainId, usePangolinWeb3 } from 'src/hooks';
+import { useChainId, usePangolinWeb3, useRefetchPangoChefSubgraph } from 'src/hooks';
 import { useLastBlockTimestampHook } from 'src/hooks/block';
 import { useTokensContract } from 'src/hooks/tokens/evm';
 import { usePangoChefContract } from 'src/hooks/useContract';
@@ -939,6 +939,7 @@ export function useHederaPangoChefStakeCallback(
   const chainId = useChainId();
   const { t } = useTranslation();
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
 
   return useMemo(() => {
     if (!poolId || !account || !chainId || !amount) {
@@ -960,6 +961,8 @@ export function useHederaPangoChefStakeCallback(
             addTransaction(response, {
               summary: t('earn.depositLiquidity'),
             });
+
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 
@@ -995,7 +998,9 @@ export function useHederaPangoChefClaimRewardCallback(
   const { t } = useTranslation();
 
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
   const png = PNG[chainId];
+
   return useMemo(() => {
     if (!poolId || !account || !chainId || !poolType) {
       return { callback: null, error: 'Missing dependencies' };
@@ -1018,6 +1023,8 @@ export function useHederaPangoChefClaimRewardCallback(
             addTransaction(response, {
               summary: t('earn.claimAccumulated', { symbol: png.symbol }),
             });
+
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 
@@ -1051,7 +1058,9 @@ export function useHederaPangoChefWithdrawCallback(withdrawData: WithdrawData): 
   const chainId = useChainId();
   const { t } = useTranslation();
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
   const { poolId, stakedAmount } = withdrawData;
+
   return useMemo(() => {
     if (!account || !chainId || !poolId || !stakedAmount) {
       return { callback: null, error: 'Missing dependencies' };
@@ -1072,6 +1081,7 @@ export function useHederaPangoChefWithdrawCallback(withdrawData: WithdrawData): 
             addTransaction(response, {
               summary: t('earn.withdrawDepositedLiquidity'),
             });
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 
@@ -1105,6 +1115,7 @@ export function useHederaPangoChefCompoundCallback(compoundData: PangoChefCompou
   const chainId = useChainId();
   const { t } = useTranslation();
   const addTransaction = useTransactionAdder();
+  const refetchPangochefSubgraph = useRefetchPangoChefSubgraph();
   const pangoChefContract = usePangoChefContract();
 
   const { poolId, isPNGPool, amountToAdd } = compoundData;
@@ -1136,6 +1147,8 @@ export function useHederaPangoChefCompoundCallback(compoundData: PangoChefCompou
             addTransaction(response, {
               summary: t('pangoChef.compoundTransactionSummary'),
             });
+
+            await refetchPangochefSubgraph();
             return response.hash;
           }
 


### PR DESCRIPTION
## Summary

- Fixed still showing stake after remove all from pangochef pool
- Fixed refetch minichef farms, add chainId in query key
- Fixed the second token is not enabled in search token drawer

## Tasks

- https://app.clickup.com/t/3pc2g7v
- https://app.clickup.com/t/3kp9706
- https://app.clickup.com/t/8669bgmpb
