### PR TITLE
fix: revert avalanche usepairs to contract calls

### DIFF
--- a/src/state/papplication/atom.ts
+++ b/src/state/papplication/atom.ts
@@ -69,7 +69,7 @@ export interface ApplicationState {
 
 const useSubgraphInitialState = {
   [ChainId.FUJI]: false,
-  [ChainId.AVALANCHE]: true,
+  [ChainId.AVALANCHE]: false,
   [ChainId.WAGMI]: false,
   [ChainId.COSTON]: false,
   [ChainId.SONGBIRD]: false,


### PR DESCRIPTION
## Summary

- Reverted avalanche subgraph to use contract calls


