### PR TITLE
fix: approve bugs

### DIFF
--- a/src/components/SwapWidget/MarketOrder/index.tsx
+++ b/src/components/SwapWidget/MarketOrder/index.tsx
@@ -259,8 +259,10 @@ const MarketOrder: React.FC<Props> = ({
   useEffect(() => {
     if (approval === ApprovalState.PENDING) {
       setApprovalSubmitted(true);
+    } else if (approval !== ApprovalState.APPROVED) {
+      setApprovalSubmitted(false);
     }
-  }, [approval, approvalSubmitted]);
+  }, [approval]);
 
   const maxAmountInput: CurrencyAmount | undefined = maxAmountSpend(chainId, currencyBalances[Field.INPUT]);
 

--- a/src/data/Allowances.ts
+++ b/src/data/Allowances.ts
@@ -40,15 +40,15 @@ export function useHederaTokenAllowance(token?: Token, owner?: string, spender?:
       const tokenId = hederaFn.hederaId(token.address);
       const ownerId = hederaFn.hederaId(owner);
       const spenderId = hederaFn.hederaId(spender);
-      console.log('aqui');
+
       const response = await hederaFn.call<{ allowances: HederaAllowanceInfo[]; links: { next: string | null } }>({
         url: `/api/v1/accounts/${ownerId}/allowances/tokens?spender.id=${spenderId}&token.id=${tokenId}`,
         method: 'GET',
       });
-      console.log('response', response);
+
       const allowances = response.allowances;
 
-      return new TokenAmount(token, allowances[0].amount_granted);
+      return new TokenAmount(token, allowances?.[0]?.amount_granted ?? 0);
     },
     {
       refetchInterval: isApprovingInfinite ? false : 1000 * 60 * 2,

--- a/src/data/Allowances.ts
+++ b/src/data/Allowances.ts
@@ -32,7 +32,6 @@ interface HederaAllowanceInfo {
 
 export function useHederaTokenAllowance(token?: Token, owner?: string, spender?: string): TokenAmount | undefined {
   const isApprovingInfinite = useIsApprovingInfinite();
-  console.log({ token, owner, spender });
   const { data } = useQuery(
     ['get-hedera-token-allowance', token?.address, owner, spender],
     async () => {

--- a/src/data/Allowances.ts
+++ b/src/data/Allowances.ts
@@ -1,5 +1,8 @@
 import { Token, TokenAmount } from '@pangolindex/sdk';
 import { useMemo } from 'react';
+import { useQuery } from 'react-query';
+import { useIsApprovingInfinite } from 'src/state/puser/hooks';
+import { hederaFn } from 'src/utils/hedera';
 import { useTokenContract } from '../hooks/useContract';
 import { useSingleCallResult } from '../state/pmulticall/hooks';
 
@@ -14,4 +17,43 @@ export function useTokenAllowance(token?: Token, owner?: string, spender?: strin
     () => (token && allowance ? new TokenAmount(token, allowance.toString()) : undefined),
     [token, allowance],
   );
+}
+
+interface HederaAllowanceInfo {
+  owner: string;
+  spender: string;
+  timestamp: {
+    from: string | null;
+    to: string | null;
+  };
+  amount_granted: number;
+  token_id: string;
+}
+
+export function useHederaTokenAllowance(token?: Token, owner?: string, spender?: string): TokenAmount | undefined {
+  const isApprovingInfinite = useIsApprovingInfinite();
+  console.log({ token, owner, spender });
+  const { data } = useQuery(
+    ['get-hedera-token-allowance', token?.address, owner, spender],
+    async () => {
+      if (!token || !owner || !spender) return undefined;
+      const tokenId = hederaFn.hederaId(token.address);
+      const ownerId = hederaFn.hederaId(owner);
+      const spenderId = hederaFn.hederaId(spender);
+      console.log('aqui');
+      const response = await hederaFn.call<{ allowances: HederaAllowanceInfo[]; links: { next: string | null } }>({
+        url: `/api/v1/accounts/${ownerId}/allowances/tokens?spender.id=${spenderId}&token.id=${tokenId}`,
+        method: 'GET',
+      });
+      console.log('response', response);
+      const allowances = response.allowances;
+
+      return new TokenAmount(token, allowances[0].amount_granted);
+    },
+    {
+      refetchInterval: isApprovingInfinite ? false : 1000 * 60 * 2,
+    },
+  );
+
+  return data;
 }

--- a/src/hooks/useApproveCallback/hedera.ts
+++ b/src/hooks/useApproveCallback/hedera.ts
@@ -4,7 +4,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
 import { ZERO_ADDRESS } from 'src/constants';
 import { ROUTER_ADDRESS, ROUTER_DAAS_ADDRESS } from 'src/constants/address';
-import { useTokenAllowance } from 'src/data/Allowances';
+import { useHederaTokenAllowance } from 'src/data/Allowances';
 import { useHederaTotalSupply } from 'src/data/TotalSupply';
 import { Field } from 'src/state/pswap/atom';
 import { useHasPendingApproval, useTransactionAdder } from 'src/state/ptransactions/hooks';
@@ -38,7 +38,7 @@ export function useHederaApproveCallback(
 
   const token = amountToken?.symbol === 'PGL' && !isLoading && data ? data : amountToken;
 
-  const currentAllowance = useTokenAllowance(token, account ?? undefined, spender);
+  const currentAllowance = useHederaTokenAllowance(token, account ?? undefined, spender);
   const pendingApproval = useHasPendingApproval(token?.address, spender);
 
   const tokenSupply = useHederaTotalSupply(token);

--- a/src/hooks/useApproveCallback/hedera.ts
+++ b/src/hooks/useApproveCallback/hedera.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { CAVAX, ChainId, CurrencyAmount, JSBI, TokenAmount, Trade } from '@pangolindex/sdk';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useQuery } from 'react-query';
 import { ZERO_ADDRESS } from 'src/constants';
 import { ROUTER_ADDRESS, ROUTER_DAAS_ADDRESS } from 'src/constants/address';
@@ -12,6 +12,7 @@ import { useIsApprovingInfinite } from 'src/state/puser/hooks';
 import { fetchHederaPGLToken } from 'src/state/pwallet/hooks/hedera';
 import { hederaFn } from 'src/utils/hedera';
 import { computeSlippageAdjustedAmounts } from 'src/utils/prices';
+import { wait } from 'src/utils/retry';
 import { usePangolinWeb3 } from '../index';
 import { ApprovalState } from './constant';
 
@@ -22,6 +23,7 @@ export function useHederaApproveCallback(
   spender?: string,
 ): [ApprovalState, () => Promise<void>] {
   const { account } = usePangolinWeb3();
+  const [isPendingApprove, setIsPendingApprove] = useState(false);
 
   const amountToken = amountToApprove instanceof TokenAmount ? amountToApprove.token : undefined;
 
@@ -50,7 +52,7 @@ export function useHederaApproveCallback(
 
     // amountToApprove will be defined if currentAllowance is
     if (currentAllowance.lessThan(amountToApprove)) {
-      if (pendingApproval) {
+      if (pendingApproval || isPendingApprove) {
         return ApprovalState.PENDING;
       } else {
         return ApprovalState.NOT_APPROVED;
@@ -58,7 +60,7 @@ export function useHederaApproveCallback(
     } else {
       return ApprovalState.APPROVED;
     }
-  }, [amountToApprove, currentAllowance, pendingApproval, spender]);
+  }, [amountToApprove, currentAllowance, pendingApproval, isPendingApprove, spender]);
 
   const addTransaction = useTransactionAdder();
 
@@ -93,6 +95,7 @@ export function useHederaApproveCallback(
     const approveAmount = approvingInfinite ? tokenSupply?.raw.toString() : _amount;
 
     try {
+      setIsPendingApprove(true);
       const response = await hederaFn.spendingApproval({
         tokenAddress: token.address,
         spender: spender,
@@ -109,8 +112,23 @@ export function useHederaApproveCallback(
     } catch (error) {
       console.debug('Failed to approve token', error);
       throw error;
+    } finally {
+      // we wait 1 second to be able to update the state with all the transactions,
+      // because as we set isPendingApprove to false, the pendingApproval still hasn't
+      // had time to be true and ends up returning ApprovalState.NOT_APPROVED
+      await wait(1000);
+      setIsPendingApprove(false);
     }
-  }, [approvalState, token, amountToApprove, spender, addTransaction, approvingInfinite, tokenSupply]);
+  }, [
+    approvalState,
+    token,
+    amountToApprove,
+    spender,
+    addTransaction,
+    setIsPendingApprove,
+    approvingInfinite,
+    tokenSupply,
+  ]);
 
   return [approvalState, approve];
 }


### PR DESCRIPTION
## Summary
1. Fixed the text `approving` in approve button only appears when the transaction has in app state, this take a time to disable the approve button, so theuser can send the approve transaction twice and spend gas token unnecessarily
2. Fetch the token allowance from hedera's api to the approve button appears more fast

## Screenshots/Videos
[Approving issue.webm](https://github.com/pangolindex/components/assets/37405304/448208e8-7177-4fa3-8092-34013f2750ea)

[Load Issue.webm](https://github.com/pangolindex/components/assets/37405304/74212c99-722c-402d-94f2-5dd3e6a851dc)




