### PR TITLE
fix: decimal issue in stake lp into farm

### DIFF
--- a/src/components/Pools/PangoChef/Stake/index.tsx
+++ b/src/components/Pools/PangoChef/Stake/index.tsx
@@ -121,10 +121,10 @@ const Stake = ({ onComplete, type, stakingInfo, combinedApr }: StakeProps) => {
     if (value === 100) {
       setTypedValue((userLiquidityUnstaked as TokenAmount).toExact());
     } else {
-      const newAmount = (userLiquidityUnstaked as TokenAmount)
-        .multiply(JSBI.BigInt(value))
-        .divide(JSBI.BigInt(100)) as TokenAmount;
-      setTypedValue(newAmount?.toFixed(0));
+      const lpToken = userLiquidityUnstaked.token;
+      const newAmount = userLiquidityUnstaked.multiply(JSBI.BigInt(value)).divide(JSBI.BigInt(100)) as TokenAmount;
+      console.log({ decimals: lpToken.decimals });
+      setTypedValue(newAmount?.toFixed(lpToken.decimals));
     }
   };
 


### PR DESCRIPTION
## Summary

- Fixed select the 25, 50 and 75% put 0 in input, the issue is we put 0 in decimails, `toFixed(0)`, because in hedera the lp tokens doesn't have decimals , and in anothers chains have decimails, so if the user has the value below 0 he does not divide this value correctly and returns 0 even if he manages to do it that

## Tasks
https://app.clickup.com/t/866aabjkq


