### PR TITLE
fix: page crash when input a value greather max uint256

### DIFF
--- a/src/state/pmint/elixir/hooks.ts
+++ b/src/state/pmint/elixir/hooks.ts
@@ -259,10 +259,14 @@ export function useDerivedMintInfo(existingPosition?: Position): DerivedMintInfo
         const pairPrice =
           dependentField === Field.CURRENCY_B ? pair.priceOf(tokenA, tokenB) : pair.priceOf(tokenB, tokenA);
         if (pairPrice.equalTo(0)) return undefined;
-        const dependentTokenAmount = pairPrice.quote(wrappedIndependentAmount, chainId);
-        return dependentCurrency === CAVAX[chainId]
-          ? CurrencyAmount.ether(dependentTokenAmount.raw, chainId)
-          : dependentTokenAmount;
+        try {
+          const dependentTokenAmount = pairPrice.quote(wrappedIndependentAmount, chainId);
+          return dependentCurrency === CAVAX[chainId]
+            ? CurrencyAmount.ether(dependentTokenAmount.raw, chainId)
+            : dependentTokenAmount;
+        } catch {
+          return undefined;
+        }
       }
       return undefined;
     } else {

--- a/src/state/pmint/hooks.ts
+++ b/src/state/pmint/hooks.ts
@@ -96,10 +96,10 @@ export function useDerivedMintInfo(
   // amounts
   const independentAmount: CurrencyAmount | undefined = tryParseAmount(
     typedValue,
-
     currencies[independentField],
     chainId,
   );
+
   const dependentAmount: CurrencyAmount | undefined = useMemo(() => {
     if (noLiquidity) {
       if (otherTypedValue && currencies[dependentField]) {
@@ -112,13 +112,17 @@ export function useDerivedMintInfo(
       const [tokenA, tokenB] = [wrappedCurrencyA, wrappedCurrencyB];
       if (tokenA && tokenB && wrappedIndependentAmount && pair && chainId) {
         const dependentCurrency = dependentField === Field.CURRENCY_B ? currencyB : currencyA;
-        const dependentTokenAmount =
-          dependentField === Field.CURRENCY_B
-            ? pair.priceOf(tokenA, tokenB).quote(wrappedIndependentAmount, chainId)
-            : pair.priceOf(tokenB, tokenA).quote(wrappedIndependentAmount, chainId);
-        return dependentCurrency === CAVAX[chainId]
-          ? CurrencyAmount.ether(dependentTokenAmount.raw, chainId)
-          : dependentTokenAmount;
+        try {
+          const dependentTokenAmount =
+            dependentField === Field.CURRENCY_B
+              ? pair.priceOf(tokenA, tokenB).quote(wrappedIndependentAmount, chainId)
+              : pair.priceOf(tokenB, tokenA).quote(wrappedIndependentAmount, chainId);
+          return dependentCurrency === CAVAX[chainId]
+            ? CurrencyAmount.ether(dependentTokenAmount.raw, chainId)
+            : dependentTokenAmount;
+        } catch {
+          return undefined;
+        }
       }
       return undefined;
     } else {


### PR DESCRIPTION
## Summary

- Fixed page crash when input a value greather max uint256
This happens when try get the amount of other token of pair using `pair.priceOf(tokenA, tokenB).quote()`, depending on the value that is in the quote it causes overflow in uint256 and enters in invariant on sdk causing the crash https://github.com/pangolindex/sdk/blob/da62dd3607e8cfef4e8b41dcc21b3be0095d6c85/src/utils.ts#L10
## Tasks

- https://app.clickup.com/t/866abrc67

