### PR TITLE
fix: bridge paterns logos overflow

### DIFF
--- a/src/components/Bridge/styles.tsx
+++ b/src/components/Bridge/styles.tsx
@@ -29,6 +29,7 @@ export const PartnerLogos = styled(Box)`
   align-items: center;
   gap: 30px;
   padding: 30px;
+  flex-wrap: wrap;
 `;
 
 export const Transactions = styled(Box)`


### PR DESCRIPTION
## Summary

- Fixed bridge paterns logos overflow in mobile

## Screenshots/Videos
- Before
![Before](https://github.com/pangolindex/components/assets/37405304/b59744c1-cb82-4be4-9c1e-436ca0df98da)

- After
![After](https://github.com/pangolindex/components/assets/37405304/ab9ca775-c658-41f8-9ca4-4e1cb16ae643)

