### PR TITLE
fix: changed elixir getPool hook from contract to subgraph

### DIFF
--- a/src/hooks/elixir/hooks/index.ts
+++ b/src/hooks/elixir/hooks/index.ts
@@ -50,7 +50,7 @@ export const usePoolsHook: UsePoolsHookType = {
   [ChainId.MOONRIVER]: useDummyPools,
   [ChainId.MOONBEAM]: useDummyPools,
   [ChainId.OP]: useDummyPools,
-  [ChainId.SKALE_BELLATRIX_TESTNET]: usePoolsViaContract,
+  [ChainId.SKALE_BELLATRIX_TESTNET]: usePoolsViaSubgraph,
 };
 
 export type UsePoolTVLHookType = {


### PR DESCRIPTION
## Summary

- Elixir `GetPool` hook changed from Contract to Subgraph.

## Tasks

- https://app.clickup.com/t/85ztcg9j5