### PR TITLE
fix: usepairs in avalanche to use contract calls

### DIFF
--- a/src/data/multiChainsHooks.ts
+++ b/src/data/multiChainsHooks.ts
@@ -18,7 +18,7 @@ export type UsePairsHookType = {
 
 export const usePairsHook: UsePairsHookType = {
   [ChainId.FUJI]: usePairsContract,
-  [ChainId.AVALANCHE]: usePairs,
+  [ChainId.AVALANCHE]: usePairsContract,
   [ChainId.WAGMI]: usePairsContract,
   [ChainId.COSTON]: usePairsContract,
   [ChainId.SONGBIRD]: usePairsContract,


### PR DESCRIPTION
## Summary

- Fix usepairs in avalanche to only use contract calls for now

## Tasks
- https://app.clickup.com/t/866apr8m1
- https://app.clickup.com/t/866apr8m1
