### PR TITLE
fix: avoid requesting rango api when blockchain/symbol is invalid

### DIFF
--- a/src/state/pbridge/providers/rango.ts
+++ b/src/state/pbridge/providers/rango.ts
@@ -55,6 +55,7 @@ export const getRangoRoutes: GetRoutes = async ({
     },
     amount: parsedAmount,
   };
+  if (!request.from.blockchain || !request.to.blockchain || !fromCurrency?.symbol || !toCurrency?.symbol) return [];
   let rangoRouteRes: QuoteResponse | SwapResponse;
 
   if (!fromAddress) {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  Before submitting a pull request, please make sure the following is done:

  1. Run `yarn` in the repository root.
  2. Run `yarn lint` make sure to fix if any linting issues
  3. Run `yarn tsc` make sure to fix any typescript issues
  4. if you have added new components make sure to add storybook for those components
-->

## Summary

This is a minor improvement for integrating Rango API for the bridge section. In this PR, I've added a check to prevent calling Rango API when blockchain or token symbol is not supported by Rango.


